### PR TITLE
Add cellular_uplink_configurations module

### DIFF
--- a/meraki/__init__.py
+++ b/meraki/__init__.py
@@ -11,6 +11,7 @@ from .api.alert_settings import AlertSettings
 from .api.bluetooth_clients import BluetoothClients
 from .api.camera_quality_retention_profiles import CameraQualityRetentionProfiles
 from .api.cameras import Cameras
+from .api.cellular_uplink_configurations import CellularUplinkConfigurations
 from .api.clients import Clients
 from .api.config_templates import ConfigTemplates
 from .api.connectivity_monitoring_destinations import ConnectivityMonitoringDestinations
@@ -149,6 +150,7 @@ class DashboardAPI(object):
         self.bluetooth_clients = BluetoothClients(self._session)
         self.camera_quality_retention_profiles = CameraQualityRetentionProfiles(self._session)
         self.cameras = Cameras(self._session)
+        self.cellular_uplink_configurations = CellularUplinkConfigurations(self._session)
         self.clients = Clients(self._session)
         self.config_templates = ConfigTemplates(self._session)
         self.connectivity_monitoring_destinations = ConnectivityMonitoringDestinations(self._session)

--- a/meraki/api/cellular_uplink_configurations.py
+++ b/meraki/api/cellular_uplink_configurations.py
@@ -1,0 +1,88 @@
+class CellularUplinkConfigurations(object):
+    def __init__(self, session):
+        super(CellularUplinkConfigurations, self).__init__()
+        self._session = session
+
+    def getCellularUplinkConfigurations(self, networkId: str, serial: str):
+        """
+        **Return the cellular uplink configurations for a device.**
+        https://api.meraki.com/api_docs
+
+        - networkId (string)
+        - serial (string)
+        """
+
+        metadata = {
+            'tags': ['Cellular Uplink Configurations'],
+            'operation': 'getCellularUplinkConfigurations',
+        }
+        resource = f'/networks/{networkId}/devices/{serial}/uplink/cellular'
+
+        return self._session.get(metadata, resource)
+
+    def createCellularUplinkConfigurations(self, networkId: str, serial: str, **kwargs):
+        """
+        **Create an uplink configuration for a device**
+        https://api.meraki.com/api_docs
+
+        - networkId (string)
+        - serial (string)
+        - apn (string): Access Point Name (APN) to send to carrier (optional)
+        - enabled (boolean): Whether this uplink is enabled (optional)
+        """
+
+        kwargs.update(locals())
+
+        metadata = {
+            'tags': ['Cellular Uplink Configurations'],
+            'operation': 'createCellularUplinkConfigurations',
+        }
+        resource = f'/networks/{networkId}/devices/{serial}/uplink/cellular'
+
+        body_params = ['apn', 'enabled']
+        payload = {k: v for (k, v) in kwargs.items() if k in body_params}
+
+        return self._session.post(metadata, resource, payload)
+
+    def getCellularUplinkConfiguration(self, networkId: str, serial: str, id: str):
+        """
+        **Return the cellular uplink configuration.**
+        https://api.meraki.com/api_docs
+
+        - networkId (string)
+        - serial (string)
+        - id (string): id for the cellular uplink configuration
+        """
+
+        metadata = {
+            'tags': ['Cellular Uplink Configurations'],
+            'operation': 'getCellularUplinkConfiguration',
+        }
+        resource = f'/networks/{networkId}/devices/{serial}/uplink/cellular/{id}'
+
+        return self._session.get(metadata, resource)
+
+    def updateCellularUplinkConfiguration(self, networkId: str, serial: str, id: str, **kwargs):
+        """
+        **Update cellular uplink configuration**
+        https://api.meraki.com/api_docs
+
+        - networkId (string)
+        - serial (string)
+        - id (string): id for the cellular uplink configuration
+        - apn (string): Access Point Name (APN) to send to carrier (optional)
+        - enabled (boolean): Whether this uplink is enabled (optional)
+        """
+
+        kwargs.update(locals())
+
+        metadata = {
+            'tags': ['Cellular Uplink Configurations'],
+            'operation': 'updateCellularUplinkConfiguration',
+        }
+        resource = f'/networks/{networkId}/devices/{serial}/uplink/cellular/{id}'
+
+        body_params = ['apn', 'enabled']
+        payload = {k: v for (k, v) in kwargs.items() if k in body_params}
+
+        return self._session.put(metadata, resource, payload)


### PR DESCRIPTION
Adding a cellular_uplink_configuration module to handle creating, updating, and getting MX cellular uplink configurations available on MX devices with integrated cellular capabilities.