### PR TITLE
added handling for a missing "Retry-After" header

### DIFF
--- a/meraki/aio/__init__.py
+++ b/meraki/aio/__init__.py
@@ -81,9 +81,10 @@ from .api.wireless_health import AsyncWirelessHealth
 from .api.wireless_settings import AsyncWirelessSettings
 from ..config import (
     API_KEY_ENVIRONMENT_VARIABLE, DEFAULT_BASE_URL, SINGLE_REQUEST_TIMEOUT, CERTIFICATE_PATH, WAIT_ON_RATE_LIMIT,
-    MAXIMUM_RETRIES, OUTPUT_LOG, LOG_PATH, LOG_FILE_PREFIX, PRINT_TO_CONSOLE, SIMULATE_API_CALLS
+    MAXIMUM_RETRIES, OUTPUT_LOG, LOG_PATH, LOG_FILE_PREFIX, PRINT_TO_CONSOLE, SIMULATE_API_CALLS, AIO_MAXIMUM_CONCURRENT_REQUESTS
 )
 
+__version__ = '0.90.1'
 
 class AsyncDashboardAPI:
     """
@@ -105,7 +106,8 @@ class AsyncDashboardAPI:
     def __init__(self, api_key=None, base_url=DEFAULT_BASE_URL, single_request_timeout=SINGLE_REQUEST_TIMEOUT,
                  certificate_path=CERTIFICATE_PATH, wait_on_rate_limit=WAIT_ON_RATE_LIMIT,
                  maximum_retries=MAXIMUM_RETRIES, output_log=OUTPUT_LOG, log_path=LOG_PATH,
-                 log_file_prefix=LOG_FILE_PREFIX, print_console=PRINT_TO_CONSOLE, simulate=SIMULATE_API_CALLS):
+                 log_file_prefix=LOG_FILE_PREFIX, print_console=PRINT_TO_CONSOLE, simulate=SIMULATE_API_CALLS,
+                 maximum_concurrent_requests=AIO_MAXIMUM_CONCURRENT_REQUESTS):
         # Check API key
         api_key = api_key or os.environ.get(API_KEY_ENVIRONMENT_VARIABLE)
         if not api_key:
@@ -144,6 +146,7 @@ class AsyncDashboardAPI:
             wait_on_rate_limit=wait_on_rate_limit,
             maximum_retries=maximum_retries,
             simulate=simulate,
+            maximum_concurrent_requests=maximum_concurrent_requests
         )
 
         # API endpoints by section

--- a/meraki/aio/__init__.py
+++ b/meraki/aio/__init__.py
@@ -101,6 +101,7 @@ class AsyncDashboardAPI:
     - log_file_prefix (string): log file name appended with date and timestamp
     - print_console (boolean): print logging output to console?
     - simulate (boolean): simulate POST/PUT/DELETE calls to prevent changes?
+    - maximum_concurrent_requests (integer): How many requests should be handled at the same time? Additional requests will be queued
     """
 
     def __init__(self, api_key=None, base_url=DEFAULT_BASE_URL, single_request_timeout=SINGLE_REQUEST_TIMEOUT,

--- a/meraki/aio/rest_session.py
+++ b/meraki/aio/rest_session.py
@@ -4,10 +4,10 @@ import time
 import ssl
 import aiohttp
 import asyncio
+import random
 
 from meraki.config import *
 from meraki.exceptions import *
-
 
 # Main module interface
 class AsyncRestSession:
@@ -21,6 +21,7 @@ class AsyncRestSession:
         wait_on_rate_limit=WAIT_ON_RATE_LIMIT,
         maximum_retries=MAXIMUM_RETRIES,
         simulate=SIMULATE_API_CALLS,
+        maximum_concurrent_requests=AIO_MAXIMUM_CONCURRENT_REQUESTS,
     ):
         super().__init__()
 
@@ -32,6 +33,8 @@ class AsyncRestSession:
         self._wait_on_rate_limit = wait_on_rate_limit
         self._maximum_retries = maximum_retries
         self._simulate = simulate
+        self._maximum_concurrent_sessions = maximum_concurrent_requests
+        self._current_sessions = 0
 
         # Update the headers of the `requests` session
         headers = None
@@ -64,6 +67,16 @@ class AsyncRestSession:
         )
 
     async def request(self, metadata, method, url, **kwargs):
+        while self._current_sessions >= self._maximum_concurrent_sessions:
+            await asyncio.sleep(0.3)  # wait for a free slot
+
+        self._current_sessions = self._current_sessions + 1
+        try:
+            return await self._request(metadata, method, url, **kwargs)
+        finally:
+            self._current_sessions = self._current_sessions - 1
+
+    async def _request(self, metadata, method, url, **kwargs):
         # Metadata on endpoint
         tag = metadata["tags"][0]
         operation = metadata["operation"]
@@ -135,7 +148,11 @@ class AsyncRestSession:
                     ]
                 # Rate limit 429 errors
                 elif status == 429:
-                    wait = int(response.headers["Retry-After"])
+                    wait = 0
+                    if "Retry-After" in response.headers:
+                        wait = int(response.headers["Retry-After"])
+                    else:
+                        wait = random.uniform(1, self._current_sessions)
                     self._logger.warning(
                         f"{tag}, {operation} - {status} {reason}, retrying in {wait} seconds"
                     )
@@ -152,10 +169,27 @@ class AsyncRestSession:
                         message = await response.json()
                     except aiohttp.client_exceptions.ContentTypeError:
                         message = (await response.text())[:100]
-                    self._logger.error(
-                        f"{tag}, {operation} - {status} {reason}, {message}"
-                    )
-                    raise AsyncAPIError(metadata, response, message)
+
+                    # Check specifically for action batch concurrency error
+                    action_batch_concurrency_error = {
+                        "errors": [
+                            "Too many concurrently executing batches. Maximum is 5 confirmed but not yet executed batches."
+                        ]
+                    }
+
+                    if message == action_batch_concurrency_error:
+                        self._logger.warning(
+                            f"{tag}, {operation} - {status} {reason}, retrying in 60 seconds"
+                        )
+                        await asyncio.sleep(60)
+
+                    # All other client-side errors
+                    else:
+                        self._logger.error(
+                            f"{tag}, {operation} - {status} {reason}, {message}"
+                        )
+                        raise AsyncAPIError(metadata, response, message)
+            raise AsyncAPIError(metadata, response, "Reached retry limit: " + message)
 
     async def get(self, metadata, url, params=None):
         metadata["method"] = "GET"

--- a/meraki/aio/rest_session.py
+++ b/meraki/aio/rest_session.py
@@ -189,7 +189,7 @@ class AsyncRestSession:
                             f"{tag}, {operation} - {status} {reason}, {message}"
                         )
                         raise AsyncAPIError(metadata, response, message)
-            raise AsyncAPIError(metadata, response, "Reached retry limit: " + message)
+            raise AsyncAPIError(metadata, response, "Reached retry limit: " + str(message))
 
     async def get(self, metadata, url, params=None):
         metadata["method"] = "GET"

--- a/meraki/config.py
+++ b/meraki/config.py
@@ -1,16 +1,16 @@
 # Package Constants
 
 # Meraki dashboard API key, set either at instantiation or as an environment variable
-API_KEY_ENVIRONMENT_VARIABLE = 'MERAKI_DASHBOARD_API_KEY'
+API_KEY_ENVIRONMENT_VARIABLE = "MERAKI_DASHBOARD_API_KEY"
 
 # Base URL preceding all endpoint resources
-DEFAULT_BASE_URL = 'https://api.meraki.com/api/v0'
+DEFAULT_BASE_URL = "https://api.meraki.com/api/v0"
 
 # Maximum number of seconds for each API call
 SINGLE_REQUEST_TIMEOUT = 60
 
 # Path for TLS/SSL certificate verification if behind local proxy
-CERTIFICATE_PATH = ''
+CERTIFICATE_PATH = ""
 
 # Retry if 429 rate limit error encountered?
 WAIT_ON_RATE_LIMIT = True
@@ -22,13 +22,16 @@ MAXIMUM_RETRIES = 2
 OUTPUT_LOG = True
 
 # Path to output log; by default, working directory of script if not specified
-LOG_PATH = ''
+LOG_PATH = ""
 
 # Log file name appended with date and timestamp
-LOG_FILE_PREFIX = 'meraki_api_'
+LOG_FILE_PREFIX = "meraki_api_"
 
 # Print output logging to console?
 PRINT_TO_CONSOLE = True
 
 # Simulate POST/PUT/DELETE calls to prevent changes?
 SIMULATE_API_CALLS = False
+
+# AIO: How many concurrent api requests should be allowed?
+AIO_MAXIMUM_CONCURRENT_REQUESTS = 3

--- a/meraki/convert_to_aio.py
+++ b/meraki/convert_to_aio.py
@@ -75,7 +75,7 @@ def compile_regex():
 
     patternInitFile[re.compile("(, SIMULATE_API_CALLS)")] = r"\1, AIO_MAXIMUM_CONCURRENT_REQUESTS"
     patternInitFile[re.compile("(, simulate=SIMULATE_API_CALLS)")] = ("\\1,\n"+" "*17)+"maximum_concurrent_requests=AIO_MAXIMUM_CONCURRENT_REQUESTS"
-    patternInitFile[re.compile("(    - simulate (boolean): .*)")] = "\\1\n    - maximum_concurrent_requests (integer): How many requests should be handled at the same time? Additional requests will be queued"
+    patternInitFile[re.compile("(    - simulate \(boolean\): .*)")] = "\\1\n    - maximum_concurrent_requests (integer): How many requests should be handled at the same time? Additional requests will be queued"
     patternInitFile[re.compile("( {12}simulate=simulate,)")] = ("\\1\n"+" "*12)+"maximum_concurrent_requests=maximum_concurrent_requests"
 
     patternInitFile[

--- a/meraki/convert_to_aio.py
+++ b/meraki/convert_to_aio.py
@@ -1,7 +1,7 @@
-'''
+"""
 SPECIAL THANKS to Heimo Stieg (https://github.com/coreGreenberet) for implementing the "aio_" examples as well as this
 script, which generates the contents of the "aio" directory for running asynchronously.
-'''
+"""
 
 
 import csv
@@ -72,6 +72,12 @@ def compile_regex():
         re.compile("class DashboardAPI\(object\):")
     ] = "class AsyncDashboardAPI:"
     patternInitFile[re.compile("(from \.api\..*import )(.*)")] = r"\1Async\2"
+
+    patternInitFile[re.compile("(, SIMULATE_API_CALLS)")] = r"\1, AIO_MAXIMUM_CONCURRENT_REQUESTS"
+    patternInitFile[re.compile("(, simulate=SIMULATE_API_CALLS)")] = ("\\1,\n"+" "*17)+"maximum_concurrent_requests=AIO_MAXIMUM_CONCURRENT_REQUESTS"
+    patternInitFile[re.compile("(    - simulate (boolean): .*)")] = "\\1\n    - maximum_concurrent_requests (integer): How many requests should be handled at the same time? Additional requests will be queued"
+    patternInitFile[re.compile("( {12}simulate=simulate,)")] = ("\\1\n"+" "*12)+"maximum_concurrent_requests=maximum_concurrent_requests"
+
     patternInitFile[
         re.compile("self\._session = RestSession\(")
     ] = "self._session = AsyncRestSession("


### PR DESCRIPTION
added maximum_concurrent_sessions parameter to AsyncDashboardAPI to limit the maximum number of concurrent requests

