### PR TITLE
Correct Appending of Log Handlers

### DIFF
--- a/meraki/__init__.py
+++ b/meraki/__init__.py
@@ -69,26 +69,32 @@ class DashboardAPI(object):
         # Configure logging
         if not suppress_logging:
             self._logger = logging.getLogger(__name__)
+            self._logger.setLevel(logging.DEBUG)
+
+            formatter = logging.Formatter(
+                fmt='%(name)12s: %(levelname)8s > %(message)s',
+                datefmt='%Y-%m-%d %H:%M:%S'
+            )
+
             if log_path and log_path[-1] != '/':
                 log_path += '/'
             self._log_file = f'{log_path}{log_file_prefix}_log__{datetime.now():%Y-%m-%d_%H-%M-%S}.log'
-            if output_log:
-                logging.basicConfig(
-                    filename=self._log_file,
-                    level=logging.DEBUG,
-                    format='%(asctime)s %(name)12s: %(levelname)8s > %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+
+            handler_console = logging.StreamHandler()
+            handler_log = logging.FileHandler(
+                filename=self._log_file
+            )
+
+            handler_console.setFormatter(formatter)
+            handler_log.setFormatter(formatter)
+
+            if output_log and not self._logger.hasHandlers():
+                self._logger.addHandler(handler_log)
                 if print_console:
-                    console = logging.StreamHandler()
-                    console.setLevel(logging.INFO)
-                    formatter = logging.Formatter('%(name)12s: %(levelname)8s > %(message)s')
-                    console.setFormatter(formatter)
-                    logging.getLogger('').addHandler(console)
-            elif print_console:
-                logging.basicConfig(
-                    level=logging.DEBUG,
-                    format='%(asctime)s %(name)12s: %(levelname)8s > %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+                    handler_console.setLevel(logging.INFO)
+                    self._logger.addHandler(handler_console)
+            elif print_console and not self._logger.hasHandlers():
+                self._logger.addHandler(handler_console)
         else:
             self._logger = None
 

--- a/meraki/aio/__init__.py
+++ b/meraki/aio/__init__.py
@@ -69,26 +69,32 @@ class AsyncDashboardAPI:
         # Configure logging
         if not suppress_logging:
             self._logger = logging.getLogger(__name__)
+            self._logger.setLevel(logging.DEBUG)
+
+            formatter = logging.Formatter(
+                fmt='%(name)12s: %(levelname)8s > %(message)s',
+                datefmt='%Y-%m-%d %H:%M:%S'
+            )
+
             if log_path and log_path[-1] != '/':
                 log_path += '/'
             self._log_file = f'{log_path}{log_file_prefix}_log__{datetime.now():%Y-%m-%d_%H-%M-%S}.log'
-            if output_log:
-                logging.basicConfig(
-                    filename=self._log_file,
-                    level=logging.DEBUG,
-                    format='%(asctime)s %(name)12s: %(levelname)8s > %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+
+            handler_console = logging.StreamHandler()
+            handler_log = logging.FileHandler(
+                filename=self._log_file
+            )
+
+            handler_console.setFormatter(formatter)
+            handler_log.setFormatter(formatter)
+
+            if output_log and not self._logger.hasHandlers():
+                self._logger.addHandler(handler_log)
                 if print_console:
-                    console = logging.StreamHandler()
-                    console.setLevel(logging.INFO)
-                    formatter = logging.Formatter('%(name)12s: %(levelname)8s > %(message)s')
-                    console.setFormatter(formatter)
-                    logging.getLogger('').addHandler(console)
-            elif print_console:
-                logging.basicConfig(
-                    level=logging.DEBUG,
-                    format='%(asctime)s %(name)12s: %(levelname)8s > %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+                    handler_console.setLevel(logging.INFO)
+                    self._logger.addHandler(handler_console)
+            elif print_console and not self._logger.hasHandlers():
+                self._logger.addHandler(handler_console)
         else:
             self._logger = None
 

--- a/meraki_v0/__init__.py
+++ b/meraki_v0/__init__.py
@@ -138,26 +138,32 @@ class DashboardAPI(object):
         # Configure logging
         if not suppress_logging:
             self._logger = logging.getLogger(__name__)
+            self._logger.setLevel(logging.DEBUG)
+
+            formatter = logging.Formatter(
+                fmt='%(name)12s: %(levelname)8s > %(message)s',
+                datefmt='%Y-%m-%d %H:%M:%S'
+            )
+
             if log_path and log_path[-1] != '/':
                 log_path += '/'
             self._log_file = f'{log_path}{log_file_prefix}_log__{datetime.now():%Y-%m-%d_%H-%M-%S}.log'
-            if output_log:
-                logging.basicConfig(
-                    filename=self._log_file,
-                    level=logging.DEBUG,
-                    format='%(asctime)s %(name)12s: %(levelname)8s > %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+
+            handler_console = logging.StreamHandler()
+            handler_log = logging.FileHandler(
+                filename=self._log_file
+            )
+
+            handler_console.setFormatter(formatter)
+            handler_log.setFormatter(formatter)
+
+            if output_log and not self._logger.hasHandlers():
+                self._logger.addHandler(handler_log)
                 if print_console:
-                    console = logging.StreamHandler()
-                    console.setLevel(logging.INFO)
-                    formatter = logging.Formatter('%(name)12s: %(levelname)8s > %(message)s')
-                    console.setFormatter(formatter)
-                    logging.getLogger('').addHandler(console)
-            elif print_console:
-                logging.basicConfig(
-                    level=logging.DEBUG,
-                    format='%(asctime)s %(name)12s: %(levelname)8s > %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+                    handler_console.setLevel(logging.INFO)
+                    self._logger.addHandler(handler_console)
+            elif print_console and not self._logger.hasHandlers():
+                self._logger.addHandler(handler_console)
         else:
             self._logger = None
 

--- a/meraki_v0/aio/__init__.py
+++ b/meraki_v0/aio/__init__.py
@@ -135,26 +135,32 @@ class AsyncDashboardAPI:
         # Configure logging
         if not suppress_logging:
             self._logger = logging.getLogger(__name__)
+            self._logger.setLevel(logging.DEBUG)
+
+            formatter = logging.Formatter(
+                fmt='%(name)12s: %(levelname)8s > %(message)s',
+                datefmt='%Y-%m-%d %H:%M:%S'
+            )
+
             if log_path and log_path[-1] != '/':
                 log_path += '/'
             self._log_file = f'{log_path}{log_file_prefix}_log__{datetime.now():%Y-%m-%d_%H-%M-%S}.log'
-            if output_log:
-                logging.basicConfig(
-                    filename=self._log_file,
-                    level=logging.DEBUG,
-                    format='%(asctime)s %(name)12s: %(levelname)8s > %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+
+            handler_console = logging.StreamHandler()
+            handler_log = logging.FileHandler(
+                filename=self._log_file
+            )
+
+            handler_console.setFormatter(formatter)
+            handler_log.setFormatter(formatter)
+
+            if output_log and not self._logger.hasHandlers():
+                self._logger.addHandler(handler_log)
                 if print_console:
-                    console = logging.StreamHandler()
-                    console.setLevel(logging.INFO)
-                    formatter = logging.Formatter('%(name)12s: %(levelname)8s > %(message)s')
-                    console.setFormatter(formatter)
-                    logging.getLogger('').addHandler(console)
-            elif print_console:
-                logging.basicConfig(
-                    level=logging.DEBUG,
-                    format='%(asctime)s %(name)12s: %(levelname)8s > %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+                    handler_console.setLevel(logging.INFO)
+                    self._logger.addHandler(handler_console)
+            elif print_console and not self._logger.hasHandlers():
+                self._logger.addHandler(handler_console)
         else:
             self._logger = None
 


### PR DESCRIPTION
The current way logging is setup is that it appends a handler logging.getHandler('') on each __init__ of DashboardAPI() (and async classes).

I replicated the way logging is set in the BasicConfig currently to be set to the logger instance at the module level. This will allow it to function cleaner when included in applications that have already configured the root logger. The log levels are interesting. The logger level is set to DEBUG and pulled down to INFO for console logging when a file is also being logged to. If no file is specified, the log level is kept at DEBUG. This holds true in this patch so it can be reviewed in future changes. Notably, because the level is set to DEBUG in logger and not in the root logger, the log file (or console with no file) will not show DEBUG messages from other code (an example would be urllib3).