### PR TITLE
FIX: API Endpoints for sensor apis were not usable

### DIFF
--- a/meraki/__init__.py
+++ b/meraki/__init__.py
@@ -10,6 +10,7 @@ from .api.appliance import Appliance
 from .api.camera import Camera
 from .api.cellularGateway import CellularGateway
 from .api.insight import Insight
+from .api.sensor import Sensor
 from .api.sm import Sm
 from .api.switch import Switch
 from .api.wireless import Wireless
@@ -113,7 +114,7 @@ class DashboardAPI(object):
         # Configure logging
         if not suppress_logging:
             self._logger = logging.getLogger(__name__)
-        
+
             if not inherit_logging_config:
                 self._logger.setLevel(logging.DEBUG)
 
@@ -171,6 +172,7 @@ class DashboardAPI(object):
         self.camera = Camera(self._session)
         self.cellularGateway = CellularGateway(self._session)
         self.insight = Insight(self._session)
+        self.sensor = Sensor(self._session)
         self.sm = Sm(self._session)
         self.switch = Switch(self._session)
         self.wireless = Wireless(self._session)

--- a/meraki/aio/__init__.py
+++ b/meraki/aio/__init__.py
@@ -10,6 +10,7 @@ from .api.devices import AsyncDevices
 from .api.insight import AsyncInsight
 from .api.networks import AsyncNetworks
 from .api.organizations import AsyncOrganizations
+from .api.sensor import AsyncSensor
 from .api.sm import AsyncSm
 from .api.switch import AsyncSwitch
 from .api.wireless import AsyncWireless
@@ -171,6 +172,7 @@ class AsyncDashboardAPI:
         self.camera = AsyncCamera(self._session)
         self.cellularGateway = AsyncCellularGateway(self._session)
         self.insight = AsyncInsight(self._session)
+        self.sensor = AsyncSensor(self._session)
         self.switch = AsyncSwitch(self._session)
         self.sm = AsyncSm(self._session)
         self.wireless = AsyncWireless(self._session)

--- a/meraki/api/batch/__init__.py
+++ b/meraki/api/batch/__init__.py
@@ -5,6 +5,7 @@ from .appliance import ActionBatchAppliance
 from .camera import ActionBatchCamera
 from .cellularGateway import ActionBatchCellularGateway
 from .insight import ActionBatchInsight
+from .sensor import ActionBatchSensor
 from .sm import ActionBatchSm
 from .switch import ActionBatchSwitch
 from .wireless import ActionBatchWireless
@@ -21,6 +22,7 @@ class Batch:
         self.camera = ActionBatchCamera()
         self.cellularGateway = ActionBatchCellularGateway()
         self.insight = ActionBatchInsight()
+        self.sensor = ActionBatchSensor()
         self.sm = ActionBatchSm()
         self.switch = ActionBatchSwitch()
         self.wireless = ActionBatchWireless()


### PR DESCRIPTION
API Endpoints for sensor apis were not accessible to the DashboardAPI model
As a result, the sensor APIs are currently unusable

This commit adds them to the model, so that we can use the sensor API's in the same way as the others