### PR TITLE
allow verbose parameter on getNetworkEvents

### DIFF
--- a/meraki/api/networks.py
+++ b/meraki/api/networks.py
@@ -741,6 +741,7 @@ class Networks(object):
         - perPage (integer): The number of entries per page returned. Acceptable range is 3 - 1000. Default is 10.
         - startingAfter (string): A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
         - endingBefore (string): A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+        - verbose (boolean): Request additional event details. Returned in the "extraData" key.
         """
 
         kwargs.update(locals())
@@ -756,7 +757,7 @@ class Networks(object):
         networkId = urllib.parse.quote(str(networkId), safe='')
         resource = f'/networks/{networkId}/events'
 
-        query_params = ['productType', 'includedEventTypes', 'excludedEventTypes', 'deviceMac', 'deviceSerial', 'deviceName', 'clientIp', 'clientMac', 'clientName', 'smDeviceMac', 'smDeviceName', 'perPage', 'startingAfter', 'endingBefore', ]
+        query_params = ['productType', 'includedEventTypes', 'excludedEventTypes', 'deviceMac', 'deviceSerial', 'deviceName', 'clientIp', 'clientMac', 'clientName', 'smDeviceMac', 'smDeviceName', 'perPage', 'startingAfter', 'endingBefore', 'verbose', ]
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['includedEventTypes', 'excludedEventTypes', ]


### PR DESCRIPTION
In Meraki Case # 09285978 I was advised to add `verbose=True` to my `getNetworkEvents` call in order to get `aid` included in `association` events. It is appended to the event in the `extraData` key.

Its not documented in the OpenAPI spec but I'd like to get rid of my local fork for making this work. If I need to fork the [OpenAPI](https://github.com/meraki/openapi) repo and add it there I can do that too.

Guessing `verbose` is available for lots of other methods but not sure where to start determining that.