### PR TITLE
Fix for #214 JSON parse failure on 204 No Content response

### DIFF
--- a/meraki/rest_session.py
+++ b/meraki/rest_session.py
@@ -100,6 +100,16 @@ class RestSession(object):
         self._req_session = requests.session()
         self._req_session.encoding = 'utf-8'
 
+        # Check minimum Python version
+        python_version_warning_string = f'This library requires Python 3.7 at minimum. Python versions 3.6 and below ' \
+                                        f'are end of life and end of support per the Python maintainers, and your ' \
+                                        f'interpreter version is {sys.version}. Please consult the readme at your ' \
+                                        f'convenience: https://github.com/meraki/dashboard-api-python'
+        if sys.version_info[0] != 3:
+            sys.exit(python_version_warning_string)
+        elif sys.version_info[1] < 7:
+            sys.exit(python_version_warning_string)
+
         # Check base URL
         if 'v0' in self._base_url:
             sys.exit(f'If you want to use the Python library with v0 paths ({self._base_url} was configured as the base'

--- a/meraki/rest_session.py
+++ b/meraki/rest_session.py
@@ -389,7 +389,12 @@ class RestSession(object):
         metadata['page'] = 1
 
         response = self.request(metadata, 'GET', url, params=params)
-        results = response.json()
+
+        # Handle GETs that produce 204 No Content responses, e.g. getOrganizationClientSearch
+        if response.status_code == 204:
+            results = None
+        else:
+            results = response.json()
 
         # For event log endpoint when using 'next' direction, so results/events are sorted chronologically
         if type(results) == dict and metadata['operation'] == 'getNetworkEvents' and direction == 'next':


### PR DESCRIPTION
Fixes #214 
There are very few GETs in Meraki dashboard API that produce 204 No Content, for which the Python equivalent is None, but for those that do, this change bypasses the attempt to JSON parse if the content is None, which produced an error.