### PR TITLE
Fix/log incorrect kwarg

### DIFF
--- a/generator/batch_function_template.jinja2
+++ b/generator/batch_function_template.jinja2
@@ -31,6 +31,7 @@
 
         {% if query_params|length > 0 %}
         query_params = [{% for param in query_params %}'{{ param }}', {% endfor %}]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         {% endif %}
@@ -44,6 +45,7 @@
         {% endif %}
         {% if body_params|length > 0 %}
         body_params = [{% for param in body_params %}'{{ param }}', {% endfor %}]
+        validate_kwargs(body_params)
         {% if batch_operation != 'destroy'%}
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         {% endif %}

--- a/generator/function_template.jinja2
+++ b/generator/function_template.jinja2
@@ -31,6 +31,7 @@
 
         {% if query_params|length > 0 %}
         query_params = [{% for param in query_params %}'{{ param }}', {% endfor %}]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         {% endif %}
@@ -44,6 +45,7 @@
         {% endif %}
         {% if body_params|length > 0 %}
         body_params = [{% for param in body_params %}'{{ param }}', {% endfor %}]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         {% endif %}

--- a/meraki/api/appliance.py
+++ b/meraki/api/appliance.py
@@ -1,5 +1,5 @@
 import urllib
-
+from meraki.common import validate_kwargs
 
 class Appliance(object):
     def __init__(self, session):
@@ -124,6 +124,7 @@ class Appliance(object):
         resource = f'/devices/{serial}/appliance/radio/settings'
 
         body_params = ['rfProfileId', 'twoFourGhzSettings', 'fiveGhzSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -226,6 +227,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/clients/{clientId}/security/events'
 
         query_params = ['t0', 't1', 'timespan', 'perPage', 'startingAfter', 'endingBefore', 'sortOrder', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -270,6 +272,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/connectivityMonitoringDestinations'
 
         body_params = ['destinations', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -321,6 +324,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/contentFiltering'
 
         body_params = ['allowedUrlPatterns', 'blockedUrlPatterns', 'blockedUrlCategories', 'urlCategoryListSize', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -384,6 +388,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/firewall/cellularFirewallRules'
 
         body_params = ['rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -456,6 +461,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/firewall/firewalledServices/{service}'
 
         body_params = ['access', 'allowedIps', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -500,6 +506,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/firewall/inboundCellularFirewallRules'
 
         body_params = ['rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -545,6 +552,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/firewall/inboundFirewallRules'
 
         body_params = ['rules', 'syslogDefaultRule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -590,6 +598,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/firewall/l3FirewallRules'
 
         body_params = ['rules', 'syslogDefaultRule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -634,6 +643,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/firewall/l7FirewallRules'
 
         body_params = ['rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -829,6 +839,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/firewall/settings'
 
         body_params = ['spoofingProtection', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -901,6 +912,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/ports/{portId}'
 
         body_params = ['enabled', 'dropUntaggedTraffic', 'type', 'vlan', 'allowedVlans', 'accessPolicy', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -947,6 +959,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/prefixes/delegated/statics'
 
         body_params = ['prefix', 'origin', 'description', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -997,6 +1010,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/prefixes/delegated/statics/{staticDelegatedPrefixId}'
 
         body_params = ['prefix', 'origin', 'description', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1065,6 +1079,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/rfProfiles'
 
         body_params = ['name', 'twoFourGhzSettings', 'fiveGhzSettings', 'perSsidSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1095,6 +1110,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/rfProfiles/{rfProfileId}'
 
         body_params = ['name', 'twoFourGhzSettings', 'fiveGhzSettings', 'perSsidSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1174,6 +1190,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/security/events'
 
         query_params = ['t0', 't1', 'timespan', 'perPage', 'startingAfter', 'endingBefore', 'sortOrder', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -1227,6 +1244,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/security/intrusion'
 
         body_params = ['mode', 'idsRulesets', 'protectedNetworks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1277,6 +1295,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/security/malware'
 
         body_params = ['mode', 'allowedUrls', 'allowedFiles', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1330,6 +1349,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/settings'
 
         body_params = ['clientTrackingMethod', 'deploymentMode', 'dynamicDns', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1377,6 +1397,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/singleLan'
 
         body_params = ['subnet', 'applianceIp', 'ipv6', 'mandatoryDhcp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1464,6 +1485,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/ssids/{number}'
 
         body_params = ['name', 'enabled', 'defaultVlanId', 'authMode', 'psk', 'radiusServers', 'encryptionMode', 'wpaEncryptionMode', 'visible', 'dhcpEnforcedDeauthentication', 'dot11w', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1511,6 +1533,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/staticRoutes'
 
         body_params = ['name', 'subnet', 'gatewayIp', 'gatewayVlanId', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1565,6 +1588,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/staticRoutes/{staticRouteId}'
 
         body_params = ['name', 'subnet', 'gatewayIp', 'gatewayVlanId', 'enabled', 'fixedIpAssignments', 'reservedIpRanges', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1630,6 +1654,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping'
 
         body_params = ['globalBandwidthLimits', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1677,6 +1702,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/customPerformanceClasses'
 
         body_params = ['name', 'maxLatency', 'maxJitter', 'maxLossPercentage', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1728,6 +1754,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/customPerformanceClasses/{customPerformanceClassId}'
 
         body_params = ['name', 'maxLatency', 'maxJitter', 'maxLossPercentage', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1778,6 +1805,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/rules'
 
         body_params = ['defaultRulesEnabled', 'rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1841,6 +1869,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/uplinkBandwidth'
 
         body_params = ['bandwidthLimits', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1894,6 +1923,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/uplinkSelection'
 
         body_params = ['activeActiveAutoVpnEnabled', 'defaultUplink', 'loadBalancingEnabled', 'failoverAndFailback', 'wanTrafficUplinkPreferences', 'vpnTrafficUplinkPreferences', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1920,6 +1950,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/vpnExclusions'
 
         body_params = ['custom', 'majorApplications', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1948,6 +1979,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/uplinks/usageHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -2005,6 +2037,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/vlans'
 
         body_params = ['id', 'name', 'subnet', 'applianceIp', 'groupPolicyId', 'templateVlanType', 'cidr', 'mask', 'ipv6', 'mandatoryDhcp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2049,6 +2082,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/vlans/settings'
 
         body_params = ['vlansEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2126,6 +2160,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/vlans/{vlanId}'
 
         body_params = ['name', 'subnet', 'applianceIp', 'groupPolicyId', 'vpnNatSubnet', 'dhcpHandling', 'dhcpRelayServerIps', 'dhcpLeaseTime', 'dhcpBootOptionsEnabled', 'dhcpBootNextServer', 'dhcpBootFilename', 'fixedIpAssignments', 'reservedIpRanges', 'dnsNameservers', 'dhcpOptions', 'templateVlanType', 'cidr', 'mask', 'ipv6', 'mandatoryDhcp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2194,6 +2229,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/vpn/bgp'
 
         body_params = ['enabled', 'asNumber', 'ibgpHoldTimer', 'neighbors', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2244,6 +2280,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/vpn/siteToSiteVpn'
 
         body_params = ['mode', 'hubs', 'subnets', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2292,6 +2329,7 @@ class Appliance(object):
         resource = f'/networks/{networkId}/appliance/warmSpare'
 
         body_params = ['enabled', 'spareSerial', 'uplinkMode', 'virtualIp1', 'virtualIp2', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2348,6 +2386,7 @@ class Appliance(object):
         resource = f'/organizations/{organizationId}/appliance/security/events'
 
         query_params = ['t0', 't1', 'timespan', 'perPage', 'startingAfter', 'endingBefore', 'sortOrder', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -2422,6 +2461,7 @@ class Appliance(object):
         resource = f'/organizations/{organizationId}/appliance/trafficShaping/vpnExclusions/byNetwork'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', ]
@@ -2460,6 +2500,7 @@ class Appliance(object):
         resource = f'/organizations/{organizationId}/appliance/uplink/statuses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'serials', 'iccids', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'iccids', ]
@@ -2493,6 +2534,7 @@ class Appliance(object):
         resource = f'/organizations/{organizationId}/appliance/uplinks/usage/byNetwork'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -2526,6 +2568,7 @@ class Appliance(object):
         resource = f'/organizations/{organizationId}/appliance/vpn/stats'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 't0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', ]
@@ -2562,6 +2605,7 @@ class Appliance(object):
         resource = f'/organizations/{organizationId}/appliance/vpn/statuses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', ]
@@ -2657,6 +2701,7 @@ class Appliance(object):
         resource = f'/organizations/{organizationId}/appliance/vpn/vpnFirewallRules'
 
         body_params = ['rules', 'syslogDefaultRule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)

--- a/meraki/api/batch/appliance.py
+++ b/meraki/api/batch/appliance.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchAppliance(object):
@@ -27,6 +28,7 @@ class ActionBatchAppliance(object):
         resource = f'/devices/{serial}/appliance/radio/settings'
 
         body_params = ['rfProfileId', 'twoFourGhzSettings', 'fiveGhzSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -114,6 +116,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/connectivityMonitoringDestinations'
 
         body_params = ['destinations', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -145,6 +148,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/firewall/l7FirewallRules'
 
         body_params = ['rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -182,6 +186,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/ports/{portId}'
 
         body_params = ['enabled', 'dropUntaggedTraffic', 'type', 'vlan', 'allowedVlans', 'accessPolicy', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -215,6 +220,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/prefixes/delegated/statics'
 
         body_params = ['prefix', 'origin', 'description', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -249,6 +255,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/prefixes/delegated/statics/{staticDelegatedPrefixId}'
 
         body_params = ['prefix', 'origin', 'description', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -309,6 +316,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/rfProfiles'
 
         body_params = ['name', 'twoFourGhzSettings', 'fiveGhzSettings', 'perSsidSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -344,6 +352,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/rfProfiles/{rfProfileId}'
 
         body_params = ['name', 'twoFourGhzSettings', 'fiveGhzSettings', 'perSsidSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -410,6 +419,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/settings'
 
         body_params = ['clientTrackingMethod', 'deploymentMode', 'dynamicDns', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -444,6 +454,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/singleLan'
 
         body_params = ['subnet', 'applianceIp', 'ipv6', 'mandatoryDhcp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -496,6 +507,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/ssids/{number}'
 
         body_params = ['name', 'enabled', 'defaultVlanId', 'authMode', 'psk', 'radiusServers', 'encryptionMode', 'wpaEncryptionMode', 'visible', 'dhcpEnforcedDeauthentication', 'dot11w', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -530,6 +542,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/customPerformanceClasses'
 
         body_params = ['name', 'maxLatency', 'maxJitter', 'maxLossPercentage', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -565,6 +578,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/customPerformanceClasses/{customPerformanceClassId}'
 
         body_params = ['name', 'maxLatency', 'maxJitter', 'maxLossPercentage', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -626,6 +640,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/rules'
 
         body_params = ['defaultRulesEnabled', 'rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -657,6 +672,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/uplinkBandwidth'
 
         body_params = ['bandwidthLimits', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -697,6 +713,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/uplinkSelection'
 
         body_params = ['activeActiveAutoVpnEnabled', 'defaultUplink', 'loadBalancingEnabled', 'failoverAndFailback', 'wanTrafficUplinkPreferences', 'vpnTrafficUplinkPreferences', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -729,6 +746,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/trafficShaping/vpnExclusions'
 
         body_params = ['custom', 'majorApplications', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -773,6 +791,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/vlans'
 
         body_params = ['id', 'name', 'subnet', 'applianceIp', 'groupPolicyId', 'templateVlanType', 'cidr', 'mask', 'ipv6', 'mandatoryDhcp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -804,6 +823,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/vlans/settings'
 
         body_params = ['vlansEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -865,6 +885,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/vlans/{vlanId}'
 
         body_params = ['name', 'subnet', 'applianceIp', 'groupPolicyId', 'vpnNatSubnet', 'dhcpHandling', 'dhcpRelayServerIps', 'dhcpLeaseTime', 'dhcpBootOptionsEnabled', 'dhcpBootNextServer', 'dhcpBootFilename', 'fixedIpAssignments', 'reservedIpRanges', 'dnsNameservers', 'dhcpOptions', 'templateVlanType', 'cidr', 'mask', 'ipv6', 'mandatoryDhcp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -925,6 +946,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/vpn/bgp'
 
         body_params = ['enabled', 'asNumber', 'ibgpHoldTimer', 'neighbors', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -962,6 +984,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/vpn/siteToSiteVpn'
 
         body_params = ['mode', 'hubs', 'subnets', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -997,6 +1020,7 @@ class ActionBatchAppliance(object):
         resource = f'/networks/{networkId}/appliance/warmSpare'
 
         body_params = ['enabled', 'spareSerial', 'uplinkMode', 'virtualIp1', 'virtualIp2', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/camera.py
+++ b/meraki/api/batch/camera.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchCamera(object):
@@ -27,6 +28,7 @@ class ActionBatchCamera(object):
         resource = f'/devices/{serial}/camera/customAnalytics'
 
         body_params = ['enabled', 'artifactId', 'parameters', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -74,6 +76,7 @@ class ActionBatchCamera(object):
         resource = f'/devices/{serial}/camera/qualityAndRetention'
 
         body_params = ['profileId', 'motionBasedRetentionEnabled', 'audioRecordingEnabled', 'restrictedBandwidthModeEnabled', 'quality', 'resolution', 'motionDetectorVersion', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -108,6 +111,7 @@ class ActionBatchCamera(object):
         resource = f'/devices/{serial}/camera/sense'
 
         body_params = ['senseEnabled', 'mqttBrokerId', 'audioDetection', 'detectionModelId', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -139,6 +143,7 @@ class ActionBatchCamera(object):
         resource = f'/devices/{serial}/camera/video/settings'
 
         body_params = ['externalRtspEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/cellularGateway.py
+++ b/meraki/api/batch/cellularGateway.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchCellularGateway(object):
@@ -26,6 +27,7 @@ class ActionBatchCellularGateway(object):
         resource = f'/devices/{serial}/cellularGateway/lan'
 
         body_params = ['reservedIpRanges', 'fixedIpAssignments', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -57,6 +59,7 @@ class ActionBatchCellularGateway(object):
         resource = f'/devices/{serial}/cellularGateway/portForwardingRules'
 
         body_params = ['rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -88,6 +91,7 @@ class ActionBatchCellularGateway(object):
         resource = f'/networks/{networkId}/cellularGateway/connectivityMonitoringDestinations'
 
         body_params = ['destinations', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -121,6 +125,7 @@ class ActionBatchCellularGateway(object):
         resource = f'/networks/{networkId}/cellularGateway/dhcp'
 
         body_params = ['dhcpLeaseTime', 'dnsNameservers', 'dnsCustomNameservers', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -153,6 +158,7 @@ class ActionBatchCellularGateway(object):
         resource = f'/networks/{networkId}/cellularGateway/subnetPool'
 
         body_params = ['mask', 'cidr', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -184,6 +190,7 @@ class ActionBatchCellularGateway(object):
         resource = f'/networks/{networkId}/cellularGateway/uplink'
 
         body_params = ['bandwidthLimits', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/devices.py
+++ b/meraki/api/batch/devices.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchDevices(object):
@@ -33,6 +34,7 @@ class ActionBatchDevices(object):
         resource = f'/devices/{serial}'
 
         body_params = ['name', 'tags', 'lat', 'lng', 'address', 'notes', 'moveMapMarker', 'switchProfileId', 'floorPlanId', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -65,6 +67,7 @@ class ActionBatchDevices(object):
         resource = f'/devices/{serial}/managementInterface'
 
         body_params = ['wan1', 'wan2', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/insight.py
+++ b/meraki/api/batch/insight.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchInsight(object):
@@ -27,6 +28,7 @@ class ActionBatchInsight(object):
         resource = f'/organizations/{organizationId}/insight/monitoredMediaServers'
 
         body_params = ['name', 'address', 'bestEffortMonitoringEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -61,6 +63,7 @@ class ActionBatchInsight(object):
         resource = f'/organizations/{organizationId}/insight/monitoredMediaServers/{monitoredMediaServerId}'
 
         body_params = ['name', 'address', 'bestEffortMonitoringEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/networks.py
+++ b/meraki/api/batch/networks.py
@@ -1,5 +1,5 @@
 import urllib
-
+from meraki.common import validate_kwargs
 
 class ActionBatchNetworks(object):
     def __init__(self):
@@ -29,6 +29,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}'
 
         body_params = ['name', 'timeZone', 'tags', 'enrollmentString', 'notes', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -86,6 +87,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/bind'
 
         body_params = ['configTemplateId', 'autoBind', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -125,6 +127,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/clients/provision'
 
         body_params = ['clients', 'devicePolicy', 'groupPolicyId', 'policiesBySecurityAppliance', 'policiesBySsid', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -255,6 +258,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/firmwareUpgrades'
 
         body_params = ['upgradeWindow', 'timezone', 'products', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -293,6 +297,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/firmwareUpgrades/rollbacks'
 
         body_params = ['product', 'time', 'reasons', 'toVersion', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -327,6 +332,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/firmwareUpgrades/staged/groups'
 
         body_params = ['name', 'description', 'isDefault', 'assignedDevices', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -391,6 +397,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/floorPlans/{floorPlanId}'
 
         body_params = ['name', 'center', 'bottomLeftCorner', 'bottomRightCorner', 'topLeftCorner', 'topRightCorner', 'imageContents', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -462,6 +469,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/groupPolicies'
 
         body_params = ['name', 'scheduling', 'bandwidth', 'firewallAndTrafficShaping', 'contentFiltering', 'splashAuthSettings', 'vlanTagging', 'bonjourForwarding', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -508,6 +516,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/groupPolicies/{groupPolicyId}'
 
         body_params = ['name', 'scheduling', 'bandwidth', 'firewallAndTrafficShaping', 'contentFiltering', 'splashAuthSettings', 'vlanTagging', 'bonjourForwarding', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -575,6 +584,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/merakiAuthUsers'
 
         body_params = ['email', 'name', 'password', 'accountType', 'emailPasswordToUser', 'isAdmin', 'authorizations', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -639,6 +649,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/merakiAuthUsers/{merakiAuthUserId}'
 
         body_params = ['name', 'password', 'emailPasswordToUser', 'authorizations', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -674,6 +685,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/mqttBrokers'
 
         body_params = ['name', 'host', 'port', 'security', 'authentication', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -710,6 +722,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/mqttBrokers/{mqttBrokerId}'
 
         body_params = ['name', 'host', 'port', 'security', 'authentication', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -771,6 +784,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/settings'
 
         body_params = ['localStatusPageEnabled', 'remoteStatusPageEnabled', 'localStatusPage', 'securePort', 'namedVlans', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -827,6 +841,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/unbind'
 
         body_params = ['retainConfigs', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -922,6 +937,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/webhooks/payloadTemplates'
 
         body_params = ['name', 'body', 'headers', 'bodyFile', 'headersFile', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -984,6 +1000,7 @@ class ActionBatchNetworks(object):
         resource = f'/networks/{networkId}/webhooks/payloadTemplates/{payloadTemplateId}'
 
         body_params = ['name', 'body', 'headers', 'bodyFile', 'headersFile', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/organizations.py
+++ b/meraki/api/batch/organizations.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchOrganizations(object):
@@ -32,6 +33,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/acls'
 
         body_params = ['name', 'description', 'rules', 'ipVersion', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -71,6 +73,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/acls/{aclId}'
 
         body_params = ['name', 'description', 'rules', 'ipVersion', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -131,6 +134,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/groups'
 
         body_params = ['name', 'sgt', 'description', 'policyObjects', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -166,6 +170,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/groups/{id}'
 
         body_params = ['name', 'sgt', 'description', 'policyObjects', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -230,6 +235,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/policies'
 
         body_params = ['sourceGroup', 'destinationGroup', 'acls', 'lastEntryRule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -269,6 +275,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/policies/{id}'
 
         body_params = ['sourceGroup', 'destinationGroup', 'acls', 'lastEntryRule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -326,6 +333,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/settings'
 
         body_params = ['enabledNetworks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -365,6 +373,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/alerts/profiles'
 
         body_params = ['type', 'alertCondition', 'recipients', 'networkTags', 'description', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -406,6 +415,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/alerts/profiles/{alertConfigId}'
 
         body_params = ['enabled', 'type', 'alertCondition', 'recipients', 'networkTags', 'description', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -471,6 +481,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/brandingPolicies'
 
         body_params = ['name', 'enabled', 'adminSettings', 'helpSettings', 'customLogo', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -503,6 +514,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/brandingPolicies/priorities'
 
         body_params = ['brandingPolicyIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -543,6 +555,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/brandingPolicies/{brandingPolicyId}'
 
         body_params = ['name', 'enabled', 'adminSettings', 'helpSettings', 'customLogo', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -602,6 +615,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/configTemplates'
 
         body_params = ['name', 'timeZone', 'copyFromNetworkId', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -635,6 +649,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/configTemplates/{configTemplateId}'
 
         body_params = ['name', 'timeZone', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -667,6 +682,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/earlyAccess/features/optIns/{optInId}'
 
         body_params = ['limitScopeToNetworks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -829,6 +845,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/licenses/{licenseId}'
 
         body_params = ['deviceSerial', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -872,6 +889,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/loginSecurity'
 
         body_params = ['enforcePasswordExpiration', 'passwordExpirationDays', 'enforceDifferentPasswords', 'numDifferentPasswords', 'enforceStrongPasswords', 'enforceAccountLockout', 'accountLockoutAttempts', 'enforceIdleTimeout', 'idleTimeoutMinutes', 'enforceTwoFactorAuth', 'enforceLoginIpRanges', 'loginIpRanges', 'apiAuthentication', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -908,6 +926,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/networks'
 
         body_params = ['name', 'productTypes', 'tags', 'timeZone', 'copyFromNetworkId', 'notes', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -941,6 +960,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/networks/combine'
 
         body_params = ['name', 'networkIds', 'enrollmentString', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -979,6 +999,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/policyObjects'
 
         body_params = ['name', 'category', 'type', 'cidr', 'fqdn', 'mask', 'ip', 'groupIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1012,6 +1033,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/policyObjects/groups'
 
         body_params = ['name', 'category', 'objectIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1045,6 +1067,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/policyObjects/groups/{policyObjectGroupId}'
 
         body_params = ['name', 'objectIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1108,6 +1131,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/policyObjects/{policyObjectId}'
 
         body_params = ['name', 'cidr', 'fqdn', 'mask', 'ip', 'groupIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1166,6 +1190,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/saml/idps'
 
         body_params = ['x509certSha1Fingerprint', 'sloLogoutUrl', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1199,6 +1224,7 @@ class ActionBatchOrganizations(object):
         resource = f'/organizations/{organizationId}/saml/idps/{idpId}'
 
         body_params = ['x509certSha1Fingerprint', 'sloLogoutUrl', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/sensor.py
+++ b/meraki/api/batch/sensor.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchSensor(object):
@@ -25,6 +26,7 @@ class ActionBatchSensor(object):
         resource = f'/devices/{serial}/sensor/relationships'
 
         body_params = ['livestream', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -60,6 +62,7 @@ class ActionBatchSensor(object):
         resource = f'/networks/{networkId}/sensor/alerts/profiles'
 
         body_params = ['name', 'schedule', 'conditions', 'recipients', 'serials', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -96,6 +99,7 @@ class ActionBatchSensor(object):
         resource = f'/networks/{networkId}/sensor/alerts/profiles/{id}'
 
         body_params = ['name', 'schedule', 'conditions', 'recipients', 'serials', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/switch.py
+++ b/meraki/api/batch/switch.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchSwitch(object):
@@ -94,6 +95,7 @@ class ActionBatchSwitch(object):
         resource = f'/devices/{serial}/switch/ports/{portId}'
 
         body_params = ['name', 'tags', 'enabled', 'poeEnabled', 'type', 'vlan', 'voiceVlan', 'allowedVlans', 'isolationEnabled', 'rstpEnabled', 'stpGuard', 'linkNegotiation', 'portScheduleId', 'udld', 'accessPolicyType', 'accessPolicyNumber', 'macAllowList', 'stickyMacAllowList', 'stickyMacAllowListLimit', 'stormControlEnabled', 'adaptivePolicyGroupId', 'peerSgtCapable', 'flexibleStackingEnabled', 'daiTrusted', 'profile', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -137,6 +139,7 @@ class ActionBatchSwitch(object):
         resource = f'/devices/{serial}/switch/routing/interfaces'
 
         body_params = ['name', 'subnet', 'interfaceIp', 'multicastRouting', 'vlanId', 'defaultGateway', 'ospfSettings', 'ospfV3', 'ipv6', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -181,6 +184,7 @@ class ActionBatchSwitch(object):
         resource = f'/devices/{serial}/switch/routing/interfaces/{interfaceId}'
 
         body_params = ['name', 'subnet', 'interfaceIp', 'multicastRouting', 'vlanId', 'defaultGateway', 'ospfSettings', 'ospfV3', 'ipv6', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -264,6 +268,7 @@ class ActionBatchSwitch(object):
         resource = f'/devices/{serial}/switch/routing/interfaces/{interfaceId}/dhcp'
 
         body_params = ['dhcpMode', 'dhcpRelayServerIps', 'dhcpLeaseTime', 'dnsNameserversOption', 'dnsCustomNameservers', 'bootOptionsEnabled', 'bootNextServer', 'bootFileName', 'dhcpOptions', 'reservedIpRanges', 'fixedIpAssignments', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -299,6 +304,7 @@ class ActionBatchSwitch(object):
         resource = f'/devices/{serial}/switch/routing/staticRoutes'
 
         body_params = ['name', 'subnet', 'nextHopIp', 'advertiseViaOspfEnabled', 'preferOverOspfRoutesEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -335,6 +341,7 @@ class ActionBatchSwitch(object):
         resource = f'/devices/{serial}/switch/routing/staticRoutes/{staticRouteId}'
 
         body_params = ['name', 'subnet', 'nextHopIp', 'advertiseViaOspfEnabled', 'preferOverOspfRoutesEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -393,6 +400,7 @@ class ActionBatchSwitch(object):
         resource = f'/devices/{serial}/switch/warmSpare'
 
         body_params = ['enabled', 'spareSerial', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -447,6 +455,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/accessPolicies'
 
         body_params = ['name', 'radiusServers', 'radius', 'guestPortBouncing', 'radiusTestingEnabled', 'radiusCoaSupportEnabled', 'radiusAccountingEnabled', 'radiusAccountingServers', 'radiusGroupAttribute', 'hostMode', 'accessPolicyType', 'increaseAccessSpeed', 'guestVlanId', 'dot1x', 'voiceVlanClients', 'urlRedirectWalledGardenEnabled', 'urlRedirectWalledGardenRanges', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -502,6 +511,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/accessPolicies/{accessPolicyNumber}'
 
         body_params = ['name', 'radiusServers', 'radius', 'guestPortBouncing', 'radiusTestingEnabled', 'radiusCoaSupportEnabled', 'radiusAccountingEnabled', 'radiusAccountingServers', 'radiusGroupAttribute', 'hostMode', 'accessPolicyType', 'increaseAccessSpeed', 'guestVlanId', 'dot1x', 'voiceVlanClients', 'urlRedirectWalledGardenEnabled', 'urlRedirectWalledGardenRanges', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -562,6 +572,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/alternateManagementInterface'
 
         body_params = ['enabled', 'vlanId', 'protocols', 'switches', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -601,6 +612,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/dhcpServerPolicy'
 
         body_params = ['alerts', 'defaultPolicy', 'allowedServers', 'blockedServers', 'arpInspection', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -668,6 +680,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/dhcpServerPolicy/arpInspection/trustedServers/{trustedServerId}'
 
         body_params = ['mac', 'vlan', 'ipv4', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -757,6 +770,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/linkAggregations'
 
         body_params = ['switchPorts', 'switchProfilePorts', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -790,6 +804,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/linkAggregations/{linkAggregationId}'
 
         body_params = ['switchPorts', 'switchProfilePorts', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -848,6 +863,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/mtu'
 
         body_params = ['defaultMtuSize', 'overrides', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -884,6 +900,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/portSchedules/{portScheduleId}'
 
         body_params = ['name', 'portSchedule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -925,6 +942,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/qosRules'
 
         body_params = ['vlan', 'protocol', 'srcPort', 'srcPortRange', 'dstPort', 'dstPortRange', 'dscp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1024,6 +1042,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/qosRules/{qosRuleId}'
 
         body_params = ['vlan', 'protocol', 'srcPort', 'srcPortRange', 'dstPort', 'dstPortRange', 'dscp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1056,6 +1075,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/routing/multicast'
 
         body_params = ['defaultSettings', 'overrides', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1184,6 +1204,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/routing/ospf'
 
         body_params = ['enabled', 'helloTimerInSeconds', 'deadTimerInSeconds', 'areas', 'v3', 'md5AuthenticationEnabled', 'md5AuthenticationKey', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1219,6 +1240,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/settings'
 
         body_params = ['vlan', 'useCombinedPower', 'powerExceptions', 'uplinkClientSampling', 'macBlocklist', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1262,6 +1284,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces'
 
         body_params = ['name', 'subnet', 'interfaceIp', 'multicastRouting', 'vlanId', 'defaultGateway', 'ospfSettings', 'ipv6', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1306,6 +1329,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces/{interfaceId}'
 
         body_params = ['name', 'subnet', 'interfaceIp', 'multicastRouting', 'vlanId', 'defaultGateway', 'ospfSettings', 'ipv6', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1392,6 +1416,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces/{interfaceId}/dhcp'
 
         body_params = ['dhcpMode', 'dhcpRelayServerIps', 'dhcpLeaseTime', 'dnsNameserversOption', 'dnsCustomNameservers', 'bootOptionsEnabled', 'bootNextServer', 'bootFileName', 'dhcpOptions', 'reservedIpRanges', 'fixedIpAssignments', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1428,6 +1453,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/staticRoutes'
 
         body_params = ['name', 'subnet', 'nextHopIp', 'advertiseViaOspfEnabled', 'preferOverOspfRoutesEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1465,6 +1491,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/staticRoutes/{staticRouteId}'
 
         body_params = ['name', 'subnet', 'nextHopIp', 'advertiseViaOspfEnabled', 'preferOverOspfRoutesEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1525,6 +1552,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/stormControl'
 
         body_params = ['broadcastThreshold', 'multicastThreshold', 'unknownUnicastThreshold', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1557,6 +1585,7 @@ class ActionBatchSwitch(object):
         resource = f'/networks/{networkId}/switch/stp'
 
         body_params = ['rstpEnabled', 'stpBridgePriority', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1626,6 +1655,7 @@ class ActionBatchSwitch(object):
         resource = f'/organizations/{organizationId}/configTemplates/{configTemplateId}/switch/profiles/{profileId}/ports/{portId}'
 
         body_params = ['name', 'tags', 'enabled', 'poeEnabled', 'type', 'vlan', 'voiceVlan', 'allowedVlans', 'isolationEnabled', 'rstpEnabled', 'stpGuard', 'linkNegotiation', 'portScheduleId', 'udld', 'accessPolicyType', 'accessPolicyNumber', 'macAllowList', 'stickyMacAllowList', 'stickyMacAllowListLimit', 'stormControlEnabled', 'flexibleStackingEnabled', 'daiTrusted', 'profile', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/batch/wireless.py
+++ b/meraki/api/batch/wireless.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class ActionBatchWireless(object):
@@ -25,6 +26,7 @@ class ActionBatchWireless(object):
         resource = f'/devices/{serial}/wireless/alternateManagementInterface/ipv6'
 
         body_params = ['addresses', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -58,6 +60,7 @@ class ActionBatchWireless(object):
         resource = f'/devices/{serial}/wireless/bluetooth/settings'
 
         body_params = ['uuid', 'major', 'minor', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -91,6 +94,7 @@ class ActionBatchWireless(object):
         resource = f'/devices/{serial}/wireless/radio/settings'
 
         body_params = ['rfProfileId', 'twoFourGhzSettings', 'fiveGhzSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -125,6 +129,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/alternateManagementInterface'
 
         body_params = ['enabled', 'vlanId', 'protocols', 'accessPoints', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -157,6 +162,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/billing'
 
         body_params = ['currency', 'plans', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -190,6 +196,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ethernet/ports/profiles'
 
         body_params = ['name', 'ports', 'usbPorts', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -287,6 +294,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ethernet/ports/profiles/{profileId}'
 
         body_params = ['name', 'ports', 'usbPorts', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -361,6 +369,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/rfProfiles'
 
         body_params = ['name', 'clientBalancingEnabled', 'minBitrateType', 'bandSelectionType', 'apBandSettings', 'twoFourGhzSettings', 'fiveGhzSettings', 'sixGhzSettings', 'transmission', 'perSsidSettings', 'flexRadios', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -410,6 +419,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/rfProfiles/{rfProfileId}'
 
         body_params = ['name', 'clientBalancingEnabled', 'minBitrateType', 'bandSelectionType', 'apBandSettings', 'twoFourGhzSettings', 'fiveGhzSettings', 'sixGhzSettings', 'transmission', 'perSsidSettings', 'flexRadios', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -476,6 +486,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/settings'
 
         body_params = ['meshingEnabled', 'ipv6BridgeEnabled', 'locationAnalyticsEnabled', 'upgradeStrategy', 'ledLightsOn', 'namedVlans', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -591,6 +602,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}'
 
         body_params = ['name', 'enabled', 'authMode', 'enterpriseAdminAccess', 'encryptionMode', 'psk', 'wpaEncryptionMode', 'dot11w', 'dot11r', 'splashPage', 'splashGuestSponsorDomains', 'oauth', 'localRadius', 'ldap', 'activeDirectory', 'radiusServers', 'radiusProxyEnabled', 'radiusTestingEnabled', 'radiusCalledStationId', 'radiusAuthenticationNasId', 'radiusServerTimeout', 'radiusServerAttemptsLimit', 'radiusFallbackEnabled', 'radiusCoaEnabled', 'radiusFailoverPolicy', 'radiusLoadBalancingPolicy', 'radiusAccountingEnabled', 'radiusAccountingServers', 'radiusAccountingInterimInterval', 'radiusAttributeForGroupPolicies', 'ipAssignmentMode', 'useVlanTagging', 'concentratorNetworkId', 'secondaryConcentratorNetworkId', 'disassociateClientsOnVpnFailover', 'vlanId', 'defaultVlanId', 'apTagsAndVlanIds', 'walledGardenEnabled', 'walledGardenRanges', 'gre', 'radiusOverride', 'radiusGuestVlanEnabled', 'radiusGuestVlanId', 'minBitrate', 'bandSelection', 'perClientBandwidthLimitUp', 'perClientBandwidthLimitDown', 'perSsidBandwidthLimitUp', 'perSsidBandwidthLimitDown', 'lanIsolationEnabled', 'visible', 'availableOnAllAps', 'availabilityTags', 'mandatoryDhcpEnabled', 'adultContentFilteringEnabled', 'dnsRewrite', 'speedBurst', 'namedVlans', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -625,6 +637,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/bonjourForwarding'
 
         body_params = ['enabled', 'rules', 'exception', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -658,6 +671,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/deviceTypeGroupPolicies'
 
         body_params = ['enabled', 'deviceTypePolicies', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -693,6 +707,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/eapOverride'
 
         body_params = ['timeout', 'identity', 'maxRetries', 'eapolKey', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -726,6 +741,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/firewall/l3FirewallRules'
 
         body_params = ['rules', 'allowLanAccess', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -758,6 +774,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/firewall/l7FirewallRules'
 
         body_params = ['rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -801,6 +818,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/hotspot20'
 
         body_params = ['enabled', 'operator', 'venue', 'networkAccessType', 'domains', 'roamConsortOis', 'mccMncs', 'naiRealms', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -836,6 +854,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/identityPsks'
 
         body_params = ['name', 'passphrase', 'groupPolicyId', 'expiresAt', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -872,6 +891,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/identityPsks/{identityPskId}'
 
         body_params = ['name', 'passphrase', 'groupPolicyId', 'expiresAt', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -933,6 +953,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/schedules'
 
         body_params = ['enabled', 'ranges', 'rangesInSeconds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -983,6 +1004,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/splash/settings'
 
         body_params = ['splashUrl', 'useSplashUrl', 'splashTimeout', 'redirectUrl', 'useRedirectUrl', 'welcomeMessage', 'splashLogo', 'splashImage', 'splashPrepaidFront', 'blockAllTrafficBeforeSignOn', 'controllerDisconnectionBehavior', 'allowSimultaneousLogins', 'guestSponsorship', 'billing', 'sentryEnrollment', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1020,6 +1042,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/trafficShaping/rules'
 
         body_params = ['trafficShapingEnabled', 'defaultRulesEnabled', 'rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,
@@ -1054,6 +1077,7 @@ class ActionBatchWireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/vpn'
 
         body_params = ['concentrator', 'splitTunnel', 'failover', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
         action = {
             "resource": resource,

--- a/meraki/api/camera.py
+++ b/meraki/api/camera.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Camera(object):
@@ -53,6 +54,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/analytics/overview'
 
         query_params = ['t0', 't1', 'timespan', 'objectType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -82,6 +84,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/analytics/recent'
 
         query_params = ['objectType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -136,6 +139,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/analytics/zones/{zoneId}/history'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', 'objectType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -182,6 +186,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/customAnalytics'
 
         body_params = ['enabled', 'artifactId', 'parameters', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -208,6 +213,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/generateSnapshot'
 
         body_params = ['timestamp', 'fullframe', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -268,6 +274,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/qualityAndRetention'
 
         body_params = ['profileId', 'motionBasedRetentionEnabled', 'audioRecordingEnabled', 'restrictedBandwidthModeEnabled', 'quality', 'resolution', 'motionDetectorVersion', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -315,6 +322,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/sense'
 
         body_params = ['senseEnabled', 'mqttBrokerId', 'audioDetection', 'detectionModelId', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -378,6 +386,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/video/settings'
 
         body_params = ['externalRtspEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -403,6 +412,7 @@ class Camera(object):
         resource = f'/devices/{serial}/camera/videoLink'
 
         query_params = ['timestamp', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -499,6 +509,7 @@ class Camera(object):
         resource = f'/networks/{networkId}/camera/qualityRetentionProfiles'
 
         body_params = ['name', 'motionBasedRetentionEnabled', 'restrictedBandwidthModeEnabled', 'audioRecordingEnabled', 'cloudArchiveEnabled', 'motionDetectorVersion', 'scheduleId', 'maxRetentionDays', 'videoSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -555,6 +566,7 @@ class Camera(object):
         resource = f'/networks/{networkId}/camera/qualityRetentionProfiles/{qualityRetentionProfileId}'
 
         body_params = ['name', 'motionBasedRetentionEnabled', 'restrictedBandwidthModeEnabled', 'audioRecordingEnabled', 'cloudArchiveEnabled', 'motionDetectorVersion', 'scheduleId', 'maxRetentionDays', 'videoSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -622,6 +634,7 @@ class Camera(object):
         resource = f'/networks/{networkId}/camera/wirelessProfiles'
 
         body_params = ['name', 'ssid', 'identity', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -691,6 +704,7 @@ class Camera(object):
         resource = f'/networks/{networkId}/camera/wirelessProfiles/{wirelessProfileId}'
 
         body_params = ['name', 'ssid', 'identity', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -756,6 +770,7 @@ class Camera(object):
         resource = f'/organizations/{organizationId}/camera/customAnalytics/artifacts'
 
         body_params = ['name', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -824,6 +839,7 @@ class Camera(object):
         resource = f'/organizations/{organizationId}/camera/onboarding/statuses'
 
         query_params = ['serials', 'networkIds', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['serials', 'networkIds', ]
@@ -856,6 +872,7 @@ class Camera(object):
         resource = f'/organizations/{organizationId}/camera/onboarding/statuses'
 
         body_params = ['serial', 'wirelessCredentialsSent', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -943,6 +960,7 @@ class Camera(object):
         resource = f'/organizations/{organizationId}/camera/roles'
 
         body_params = ['name', 'appliedOnDevices', 'appliedOnNetworks', 'appliedOrgWide', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1015,6 +1033,7 @@ class Camera(object):
         resource = f'/organizations/{organizationId}/camera/roles/{roleId}'
 
         body_params = ['name', 'appliedOnDevices', 'appliedOnNetworks', 'appliedOrgWide', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)

--- a/meraki/api/cellularGateway.py
+++ b/meraki/api/cellularGateway.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class CellularGateway(object):
@@ -47,6 +48,7 @@ class CellularGateway(object):
         resource = f'/devices/{serial}/cellularGateway/lan'
 
         body_params = ['reservedIpRanges', 'fixedIpAssignments', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -91,6 +93,7 @@ class CellularGateway(object):
         resource = f'/devices/{serial}/cellularGateway/portForwardingRules'
 
         body_params = ['rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -135,6 +138,7 @@ class CellularGateway(object):
         resource = f'/networks/{networkId}/cellularGateway/connectivityMonitoringDestinations'
 
         body_params = ['destinations', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -181,6 +185,7 @@ class CellularGateway(object):
         resource = f'/networks/{networkId}/cellularGateway/dhcp'
 
         body_params = ['dhcpLeaseTime', 'dnsNameservers', 'dnsCustomNameservers', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -226,6 +231,7 @@ class CellularGateway(object):
         resource = f'/networks/{networkId}/cellularGateway/subnetPool'
 
         body_params = ['mask', 'cidr', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -270,6 +276,7 @@ class CellularGateway(object):
         resource = f'/networks/{networkId}/cellularGateway/uplink'
 
         body_params = ['bandwidthLimits', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -302,6 +309,7 @@ class CellularGateway(object):
         resource = f'/organizations/{organizationId}/cellularGateway/uplink/statuses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'serials', 'iccids', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'iccids', ]

--- a/meraki/api/devices.py
+++ b/meraki/api/devices.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Devices(object):
@@ -54,6 +55,7 @@ class Devices(object):
         resource = f'/devices/{serial}'
 
         body_params = ['name', 'tags', 'lat', 'lng', 'address', 'notes', 'moveMapMarker', 'switchProfileId', 'floorPlanId', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -81,6 +83,7 @@ class Devices(object):
         resource = f'/devices/{serial}/blinkLeds'
 
         body_params = ['duration', 'period', 'duty', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -126,6 +129,7 @@ class Devices(object):
         resource = f'/devices/{serial}/cellular/sims'
 
         body_params = ['sims', 'simFailover', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -152,6 +156,7 @@ class Devices(object):
         resource = f'/devices/{serial}/clients'
 
         query_params = ['t0', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -179,6 +184,7 @@ class Devices(object):
         resource = f'/devices/{serial}/liveTools/ping'
 
         body_params = ['target', 'count', 'callback', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -226,6 +232,7 @@ class Devices(object):
         resource = f'/devices/{serial}/liveTools/pingDevice'
 
         body_params = ['count', 'callback', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -300,6 +307,7 @@ class Devices(object):
         resource = f'/devices/{serial}/lossAndLatencyHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', 'uplink', 'ip', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -343,8 +351,9 @@ class Devices(object):
         }
         serial = urllib.parse.quote(str(serial), safe='')
         resource = f'/devices/{serial}/managementInterface'
-
+        
         body_params = ['wan1', 'wan2', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)

--- a/meraki/api/insight.py
+++ b/meraki/api/insight.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Insight(object):
@@ -32,6 +33,7 @@ class Insight(object):
         resource = f'/networks/{networkId}/insight/applications/{applicationId}/healthByTime'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -97,6 +99,7 @@ class Insight(object):
         resource = f'/organizations/{organizationId}/insight/monitoredMediaServers'
 
         body_params = ['name', 'address', 'bestEffortMonitoringEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -147,6 +150,7 @@ class Insight(object):
         resource = f'/organizations/{organizationId}/insight/monitoredMediaServers/{monitoredMediaServerId}'
 
         body_params = ['name', 'address', 'bestEffortMonitoringEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)

--- a/meraki/api/licensing.py
+++ b/meraki/api/licensing.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Licensing(object):
@@ -33,6 +34,7 @@ class Licensing(object):
         resource = f'/organizations/{organizationId}/licensing/coterm/licenses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'invalidated', 'expired', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)

--- a/meraki/api/organizations.py
+++ b/meraki/api/organizations.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Organizations(object):
@@ -43,6 +44,7 @@ class Organizations(object):
         resource = f'/organizations'
 
         body_params = ['name', 'management', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -89,6 +91,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}'
 
         body_params = ['name', 'management', 'api', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -136,6 +139,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/actionBatches'
 
         body_params = ['confirmed', 'synchronous', 'actions', 'callback', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -165,6 +169,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/actionBatches'
 
         query_params = ['status', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -235,6 +240,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/actionBatches/{actionBatchId}'
 
         body_params = ['confirmed', 'synchronous', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -286,6 +292,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/acls'
 
         body_params = ['name', 'description', 'rules', 'ipVersion', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -341,6 +348,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/acls/{aclId}'
 
         body_params = ['name', 'description', 'rules', 'ipVersion', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -409,6 +417,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/groups'
 
         body_params = ['name', 'sgt', 'description', 'policyObjects', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -460,6 +469,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/groups/{id}'
 
         body_params = ['name', 'sgt', 'description', 'policyObjects', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -551,6 +561,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/policies'
 
         body_params = ['sourceGroup', 'destinationGroup', 'acls', 'lastEntryRule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -606,6 +617,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/policies/{id}'
 
         body_params = ['sourceGroup', 'destinationGroup', 'acls', 'lastEntryRule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -671,6 +683,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/adaptivePolicy/settings'
 
         body_params = ['enabledNetworks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -727,6 +740,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/admins'
 
         body_params = ['email', 'name', 'orgAccess', 'tags', 'networks', 'authenticationMethod', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -761,6 +775,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/admins/{adminId}'
 
         body_params = ['name', 'orgAccess', 'tags', 'networks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -834,6 +849,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/alerts/profiles'
 
         body_params = ['type', 'alertCondition', 'recipients', 'networkTags', 'description', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -870,6 +886,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/alerts/profiles/{alertConfigId}'
 
         body_params = ['enabled', 'type', 'alertCondition', 'recipients', 'networkTags', 'description', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -938,6 +955,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/apiRequests'
 
         query_params = ['t0', 't1', 'timespan', 'perPage', 'startingAfter', 'endingBefore', 'adminId', 'path', 'method', 'responseCode', 'sourceIp', 'userAgent', 'version', 'operationIds', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['operationIds', ]
@@ -971,6 +989,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/apiRequests/overview'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1008,6 +1027,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/apiRequests/overview/responseCodes/byInterval'
 
         query_params = ['t0', 't1', 'timespan', 'interval', 'version', 'operationIds', 'sourceIps', 'adminIds', 'userAgent', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['operationIds', 'sourceIps', 'adminIds', ]
@@ -1066,6 +1086,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/brandingPolicies'
 
         body_params = ['name', 'enabled', 'adminSettings', 'helpSettings', 'customLogo', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1111,6 +1132,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/brandingPolicies/priorities'
 
         body_params = ['brandingPolicyIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1167,6 +1189,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/brandingPolicies/{brandingPolicyId}'
 
         body_params = ['name', 'enabled', 'adminSettings', 'helpSettings', 'customLogo', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1215,6 +1238,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/claim'
 
         body_params = ['orders', 'serials', 'licenses', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1242,6 +1266,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/clients/bandwidthUsageHistory'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1269,6 +1294,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/clients/overview'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1299,6 +1325,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/clients/search'
 
         query_params = ['mac', 'perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -1370,6 +1397,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/configTemplates'
 
         body_params = ['name', 'timeZone', 'copyFromNetworkId', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1398,6 +1426,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/configTemplates/{configTemplateId}'
 
         body_params = ['name', 'timeZone', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1474,6 +1503,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/configurationChanges'
 
         query_params = ['t0', 't1', 'timespan', 'perPage', 'startingAfter', 'endingBefore', 'networkId', 'adminId', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -1521,6 +1551,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'configurationUpdatedAfter', 'networkIds', 'productTypes', 'tags', 'tagsFilterType', 'name', 'mac', 'serial', 'model', 'macs', 'serials', 'sensorMetrics', 'sensorAlertProfileIds', 'models', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'productTypes', 'tags', 'macs', 'serials', 'sensorMetrics', 'sensorAlertProfileIds', 'models', ]
@@ -1565,6 +1596,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices/availabilities'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'productTypes', 'serials', 'tags', 'tagsFilterType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'productTypes', 'serials', 'tags', ]
@@ -1607,6 +1639,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices/availabilities/changeHistory'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', 'serials', 'productTypes', 'networkIds', 'statuses', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['serials', 'productTypes', 'networkIds', 'statuses', ]
@@ -1651,6 +1684,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices/powerModules/statuses/byDevice'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'productTypes', 'serials', 'tags', 'tagsFilterType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'productTypes', 'serials', 'tags', ]
@@ -1699,6 +1733,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices/provisioning/statuses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'productTypes', 'serials', 'status', 'tags', 'tagsFilterType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'productTypes', 'serials', 'tags', ]
@@ -1745,6 +1780,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices/statuses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'serials', 'statuses', 'productTypes', 'models', 'tags', 'tagsFilterType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'statuses', 'productTypes', 'models', 'tags', ]
@@ -1777,6 +1813,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices/statuses/overview'
 
         query_params = ['productTypes', 'networkIds', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['productTypes', 'networkIds', ]
@@ -1821,6 +1858,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices/uplinks/addresses/byDevice'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'productTypes', 'serials', 'tags', 'tagsFilterType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'productTypes', 'serials', 'tags', ]
@@ -1860,6 +1898,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/devices/uplinksLossAndLatency'
 
         query_params = ['t0', 't1', 'timespan', 'uplink', 'ip', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1924,6 +1963,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/earlyAccess/features/optIns'
 
         body_params = ['shortName', 'limitScopeToNetworks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1972,6 +2012,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/earlyAccess/features/optIns/{optInId}'
 
         body_params = ['limitScopeToNetworks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2024,6 +2065,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/firmware/upgrades'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'status', 'productTypes', ]
+        validate_kwargs(body_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['status', 'productTypes', ]
@@ -2064,6 +2106,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/firmware/upgrades/byDevice'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'serials', 'macs', 'firmwareUpgradeBatchIds', 'upgradeStatuses', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'macs', 'firmwareUpgradeBatchIds', 'upgradeStatuses', ]
@@ -2097,6 +2140,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/inventory/claim'
 
         body_params = ['orders', 'serials', 'licenses', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2143,6 +2187,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/inventory/devices'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'usedState', 'search', 'macs', 'networkIds', 'serials', 'models', 'orderNumbers', 'tags', 'tagsFilterType', 'productTypes', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['macs', 'networkIds', 'serials', 'models', 'orderNumbers', 'tags', 'productTypes', ]
@@ -2198,6 +2243,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/inventory/onboarding/cloudMonitoring/exportEvents'
 
         body_params = ['logEvent', 'timestamp', 'targetOS', 'request', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2289,6 +2335,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/inventory/onboarding/cloudMonitoring/networks'
 
         query_params = ['deviceType', 'search', 'perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -2339,6 +2386,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/inventory/release'
 
         body_params = ['serials', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2375,6 +2423,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/licenses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'deviceSerial', 'networkId', 'state', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -2548,6 +2597,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/licenses/{licenseId}'
 
         body_params = ['deviceSerial', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2604,6 +2654,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/loginSecurity'
 
         body_params = ['enforcePasswordExpiration', 'passwordExpirationDays', 'enforceDifferentPasswords', 'numDifferentPasswords', 'enforceStrongPasswords', 'enforceAccountLockout', 'accountLockoutAttempts', 'enforceIdleTimeout', 'idleTimeoutMinutes', 'enforceTwoFactorAuth', 'enforceLoginIpRanges', 'loginIpRanges', 'apiAuthentication', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2641,6 +2692,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/networks'
 
         query_params = ['configTemplateId', 'isBoundToConfigTemplate', 'tags', 'tagsFilterType', 'perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['tags', ]
@@ -2677,6 +2729,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/networks'
 
         body_params = ['name', 'productTypes', 'tags', 'timeZone', 'copyFromNetworkId', 'notes', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2704,6 +2757,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/networks/combine'
 
         body_params = ['name', 'networkIds', 'enrollmentString', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2733,6 +2787,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/openapiSpec'
 
         query_params = ['version', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -2762,6 +2817,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/policyObjects'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -2794,6 +2850,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/policyObjects'
 
         body_params = ['name', 'category', 'type', 'cidr', 'fqdn', 'mask', 'ip', 'groupIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2823,6 +2880,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/policyObjects/groups'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -2850,6 +2908,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/policyObjects/groups'
 
         body_params = ['name', 'category', 'objectIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2899,6 +2958,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/policyObjects/groups/{policyObjectGroupId}'
 
         body_params = ['name', 'objectIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2973,6 +3033,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/policyObjects/{policyObjectId}'
 
         body_params = ['name', 'cidr', 'fqdn', 'mask', 'ip', 'groupIds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -3038,6 +3099,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/saml'
 
         body_params = ['enabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -3083,6 +3145,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/saml/idps'
 
         body_params = ['x509certSha1Fingerprint', 'sloLogoutUrl', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -3111,6 +3174,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/saml/idps/{idpId}'
 
         body_params = ['x509certSha1Fingerprint', 'sloLogoutUrl', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -3204,6 +3268,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/samlRoles'
 
         body_params = ['role', 'orgAccess', 'tags', 'networks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -3259,6 +3324,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/samlRoles/{samlRoleId}'
 
         body_params = ['role', 'orgAccess', 'tags', 'networks', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -3337,6 +3403,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/snmp'
 
         body_params = ['v2cEnabled', 'v3Enabled', 'v3AuthMode', 'v3AuthPass', 'v3PrivMode', 'v3PrivPass', 'peerIps', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -3364,6 +3431,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/summary/top/appliances/byUtilization'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -3391,6 +3459,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/summary/top/clients/byUsage'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -3418,6 +3487,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/summary/top/clients/manufacturers/byUsage'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -3445,6 +3515,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/summary/top/devices/byUsage'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -3472,6 +3543,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/summary/top/devices/models/byUsage'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -3499,6 +3571,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/summary/top/ssids/byUsage'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -3526,6 +3599,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/summary/top/switches/byEnergyUsage'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -3558,6 +3632,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/uplinks/statuses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'serials', 'iccids', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'iccids', ]
@@ -3593,6 +3668,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/webhooks/alertTypes'
 
         query_params = ['productType', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -3647,6 +3723,7 @@ class Organizations(object):
         resource = f'/organizations/{organizationId}/webhooks/logs'
 
         query_params = ['t0', 't1', 'timespan', 'perPage', 'startingAfter', 'endingBefore', 'url', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)

--- a/meraki/api/sensor.py
+++ b/meraki/api/sensor.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Sensor(object):
@@ -46,6 +47,7 @@ class Sensor(object):
         resource = f'/devices/{serial}/sensor/relationships'
 
         body_params = ['livestream', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -93,6 +95,7 @@ class Sensor(object):
         resource = f'/networks/{networkId}/sensor/alerts/overview/byMetric'
 
         query_params = ['t0', 't1', 'timespan', 'interval', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -141,6 +144,7 @@ class Sensor(object):
         resource = f'/networks/{networkId}/sensor/alerts/profiles'
 
         body_params = ['name', 'schedule', 'conditions', 'recipients', 'serials', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -193,6 +197,7 @@ class Sensor(object):
         resource = f'/networks/{networkId}/sensor/alerts/profiles/{id}'
 
         body_params = ['name', 'schedule', 'conditions', 'recipients', 'serials', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -335,6 +340,7 @@ class Sensor(object):
         resource = f'/organizations/{organizationId}/sensor/readings/history'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', 'networkIds', 'serials', 'metrics', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'metrics', ]
@@ -373,6 +379,7 @@ class Sensor(object):
         resource = f'/organizations/{organizationId}/sensor/readings/latest'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'serials', 'metrics', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'metrics', ]

--- a/meraki/api/sm.py
+++ b/meraki/api/sm.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Sm(object):
@@ -89,6 +90,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices'
 
         query_params = ['fields', 'wifiMacs', 'serials', 'ids', 'uuids', 'scope', 'perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['fields', 'wifiMacs', 'serials', 'ids', 'uuids', 'scope', ]
@@ -123,6 +125,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/checkin'
 
         body_params = ['wifiMacs', 'ids', 'serials', 'scope', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -151,6 +154,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/fields'
 
         body_params = ['wifiMac', 'id', 'serial', 'deviceFields', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -180,6 +184,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/lock'
 
         body_params = ['wifiMacs', 'ids', 'serials', 'scope', 'pin', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -210,6 +215,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/modifyTags'
 
         body_params = ['wifiMacs', 'ids', 'serials', 'scope', 'tags', 'updateAction', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -239,6 +245,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/move'
 
         body_params = ['wifiMacs', 'ids', 'serials', 'scope', 'newNetwork', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -267,6 +274,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/wipe'
 
         body_params = ['wifiMac', 'id', 'serial', 'pin', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -340,6 +348,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/{deviceId}/connectivity'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(body_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -371,6 +380,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/{deviceId}/desktopLogs'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -402,6 +412,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/{deviceId}/deviceCommandLogs'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -451,6 +462,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/{deviceId}/installApps'
 
         body_params = ['appIds', 'force', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -503,6 +515,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/devices/{deviceId}/performanceHistory'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -700,6 +713,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/targetGroups'
 
         query_params = ['withDetails', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -726,6 +740,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/targetGroups'
 
         body_params = ['name', 'scope', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -753,6 +768,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/targetGroups/{targetGroupId}'
 
         query_params = ['withDetails', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -781,6 +797,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/targetGroups/{targetGroupId}'
 
         body_params = ['name', 'scope', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -831,6 +848,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/trustedAccessConfigs'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -860,6 +878,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/userAccessDevices'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -909,6 +928,7 @@ class Sm(object):
         resource = f'/networks/{networkId}/sm/users'
 
         query_params = ['ids', 'usernames', 'emails', 'scope', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['ids', 'usernames', 'emails', 'scope', ]

--- a/meraki/api/switch.py
+++ b/meraki/api/switch.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Switch(object):
@@ -72,6 +73,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/ports/statuses'
 
         query_params = ['t0', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -98,6 +100,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/ports/statuses/packets'
 
         query_params = ['t0', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -183,6 +186,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/ports/{portId}'
 
         body_params = ['name', 'tags', 'enabled', 'poeEnabled', 'type', 'vlan', 'voiceVlan', 'allowedVlans', 'isolationEnabled', 'rstpEnabled', 'stpGuard', 'linkNegotiation', 'portScheduleId', 'udld', 'accessPolicyType', 'accessPolicyNumber', 'macAllowList', 'stickyMacAllowList', 'stickyMacAllowListLimit', 'stormControlEnabled', 'adaptivePolicyGroupId', 'peerSgtCapable', 'flexibleStackingEnabled', 'daiTrusted', 'profile', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -239,6 +243,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/routing/interfaces'
 
         body_params = ['name', 'subnet', 'interfaceIp', 'multicastRouting', 'vlanId', 'defaultGateway', 'ospfSettings', 'ospfV3', 'ipv6', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -299,6 +304,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/routing/interfaces/{interfaceId}'
 
         body_params = ['name', 'subnet', 'interfaceIp', 'multicastRouting', 'vlanId', 'defaultGateway', 'ospfSettings', 'ospfV3', 'ipv6', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -393,6 +399,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/routing/interfaces/{interfaceId}/dhcp'
 
         body_params = ['dhcpMode', 'dhcpRelayServerIps', 'dhcpLeaseTime', 'dnsNameserversOption', 'dnsCustomNameservers', 'bootOptionsEnabled', 'bootNextServer', 'bootFileName', 'dhcpOptions', 'reservedIpRanges', 'fixedIpAssignments', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -441,6 +448,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/routing/staticRoutes'
 
         body_params = ['name', 'subnet', 'nextHopIp', 'advertiseViaOspfEnabled', 'preferOverOspfRoutesEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -493,6 +501,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/routing/staticRoutes/{staticRouteId}'
 
         body_params = ['name', 'subnet', 'nextHopIp', 'advertiseViaOspfEnabled', 'preferOverOspfRoutesEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -559,6 +568,7 @@ class Switch(object):
         resource = f'/devices/{serial}/switch/warmSpare'
 
         body_params = ['enabled', 'spareSerial', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -670,6 +680,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/accessPolicies'
 
         body_params = ['name', 'radiusServers', 'radius', 'guestPortBouncing', 'radiusTestingEnabled', 'radiusCoaSupportEnabled', 'radiusAccountingEnabled', 'radiusAccountingServers', 'radiusGroupAttribute', 'hostMode', 'accessPolicyType', 'increaseAccessSpeed', 'guestVlanId', 'dot1x', 'voiceVlanClients', 'urlRedirectWalledGardenEnabled', 'urlRedirectWalledGardenRanges', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -741,6 +752,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/accessPolicies/{accessPolicyNumber}'
 
         body_params = ['name', 'radiusServers', 'radius', 'guestPortBouncing', 'radiusTestingEnabled', 'radiusCoaSupportEnabled', 'radiusAccountingEnabled', 'radiusAccountingServers', 'radiusGroupAttribute', 'hostMode', 'accessPolicyType', 'increaseAccessSpeed', 'guestVlanId', 'dot1x', 'voiceVlanClients', 'urlRedirectWalledGardenEnabled', 'urlRedirectWalledGardenRanges', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -809,6 +821,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/alternateManagementInterface'
 
         body_params = ['enabled', 'vlanId', 'protocols', 'switches', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -840,6 +853,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/dhcp/v4/servers/seen'
 
         query_params = ['t0', 'timespan', 'perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -892,6 +906,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/dhcpServerPolicy'
 
         body_params = ['alerts', 'defaultPolicy', 'allowedServers', 'blockedServers', 'arpInspection', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -921,6 +936,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/dhcpServerPolicy/arpInspection/trustedServers'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -977,6 +993,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/dhcpServerPolicy/arpInspection/trustedServers/{trustedServerId}'
 
         body_params = ['mac', 'vlan', 'ipv4', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1027,6 +1044,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/dhcpServerPolicy/arpInspection/warnings/byDevice'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -1116,6 +1134,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/linkAggregations'
 
         body_params = ['switchPorts', 'switchProfilePorts', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1144,6 +1163,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/linkAggregations/{linkAggregationId}'
 
         body_params = ['switchPorts', 'switchProfilePorts', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1210,6 +1230,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/mtu'
 
         body_params = ['defaultMtuSize', 'overrides', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1258,6 +1279,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/portSchedules'
 
         body_params = ['name', 'portSchedule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1310,6 +1332,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/portSchedules/{portScheduleId}'
 
         body_params = ['name', 'portSchedule', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1364,6 +1387,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/qosRules'
 
         body_params = ['vlan', 'protocol', 'srcPort', 'srcPortRange', 'dstPort', 'dstPortRange', 'dscp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1487,6 +1511,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/qosRules/{qosRuleId}'
 
         body_params = ['vlan', 'protocol', 'srcPort', 'srcPortRange', 'dstPort', 'dstPortRange', 'dscp', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1532,6 +1557,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/routing/multicast'
 
         body_params = ['defaultSettings', 'overrides', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1697,6 +1723,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/routing/ospf'
 
         body_params = ['enabled', 'helloTimerInSeconds', 'deadTimerInSeconds', 'areas', 'v3', 'md5AuthenticationEnabled', 'md5AuthenticationKey', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1745,6 +1772,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/settings'
 
         body_params = ['vlan', 'useCombinedPower', 'powerExceptions', 'uplinkClientSampling', 'macBlocklist', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1945,6 +1973,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces'
 
         body_params = ['name', 'subnet', 'interfaceIp', 'multicastRouting', 'vlanId', 'defaultGateway', 'ospfSettings', 'ipv6', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2008,6 +2037,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces/{interfaceId}'
 
         body_params = ['name', 'subnet', 'interfaceIp', 'multicastRouting', 'vlanId', 'defaultGateway', 'ospfSettings', 'ipv6', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2109,6 +2139,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces/{interfaceId}/dhcp'
 
         body_params = ['dhcpMode', 'dhcpRelayServerIps', 'dhcpLeaseTime', 'dnsNameserversOption', 'dnsCustomNameservers', 'bootOptionsEnabled', 'bootNextServer', 'bootFileName', 'dhcpOptions', 'reservedIpRanges', 'fixedIpAssignments', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2161,6 +2192,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/staticRoutes'
 
         body_params = ['name', 'subnet', 'nextHopIp', 'advertiseViaOspfEnabled', 'preferOverOspfRoutesEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2217,6 +2249,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/stacks/{switchStackId}/routing/staticRoutes/{staticRouteId}'
 
         body_params = ['name', 'subnet', 'nextHopIp', 'advertiseViaOspfEnabled', 'preferOverOspfRoutesEnabled', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2286,6 +2319,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/stormControl'
 
         body_params = ['broadcastThreshold', 'multicastThreshold', 'unknownUnicastThreshold', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2331,6 +2365,7 @@ class Switch(object):
         resource = f'/networks/{networkId}/switch/stp'
 
         body_params = ['rstpEnabled', 'stpBridgePriority', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2466,6 +2501,7 @@ class Switch(object):
         resource = f'/organizations/{organizationId}/configTemplates/{configTemplateId}/switch/profiles/{profileId}/ports/{portId}'
 
         body_params = ['name', 'tags', 'enabled', 'poeEnabled', 'type', 'vlan', 'voiceVlan', 'allowedVlans', 'isolationEnabled', 'rstpEnabled', 'stpGuard', 'linkNegotiation', 'portScheduleId', 'udld', 'accessPolicyType', 'accessPolicyNumber', 'macAllowList', 'stickyMacAllowList', 'stickyMacAllowListLimit', 'stormControlEnabled', 'flexibleStackingEnabled', 'daiTrusted', 'profile', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2493,6 +2529,7 @@ class Switch(object):
         resource = f'/organizations/{organizationId}/summary/switch/power/history'
 
         query_params = ['t0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -2519,6 +2556,7 @@ class Switch(object):
         resource = f'/organizations/{organizationId}/switch/devices/clone'
 
         body_params = ['sourceSerial', 'targetSerials', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -2556,6 +2594,7 @@ class Switch(object):
         resource = f'/organizations/{organizationId}/switch/ports/bySwitch'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', 'portProfileIds', 'name', 'mac', 'macs', 'serial', 'serials', 'configurationUpdatedAfter', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'portProfileIds', 'macs', 'serials', ]

--- a/meraki/api/wireless.py
+++ b/meraki/api/wireless.py
@@ -1,4 +1,5 @@
 import urllib
+from meraki.common import validate_kwargs
 
 
 class Wireless(object):
@@ -27,6 +28,7 @@ class Wireless(object):
         resource = f'/devices/{serial}/wireless/alternateManagementInterface/ipv6'
 
         body_params = ['addresses', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -73,6 +75,7 @@ class Wireless(object):
         resource = f'/devices/{serial}/wireless/bluetooth/settings'
 
         body_params = ['uuid', 'major', 'minor', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -108,6 +111,7 @@ class Wireless(object):
         resource = f'/devices/{serial}/wireless/connectionStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -144,6 +148,7 @@ class Wireless(object):
         resource = f'/devices/{serial}/wireless/latencyStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', 'fields', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -190,6 +195,7 @@ class Wireless(object):
         resource = f'/devices/{serial}/wireless/radio/settings'
 
         body_params = ['rfProfileId', 'twoFourGhzSettings', 'fiveGhzSettings', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -235,6 +241,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/airMarshal'
 
         query_params = ['t0', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -282,6 +289,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/alternateManagementInterface'
 
         body_params = ['enabled', 'vlanId', 'protocols', 'accessPoints', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -327,6 +335,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/billing'
 
         body_params = ['currency', 'plans', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -380,6 +389,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/bluetooth/settings'
 
         body_params = ['scanningEnabled', 'advertisingEnabled', 'uuid', 'majorMinorAssignmentMode', 'major', 'minor', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -417,6 +427,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/channelUtilizationHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', 'autoResolution', 'clientId', 'deviceSerial', 'apTag', 'band', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -455,6 +466,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/clientCountHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', 'autoResolution', 'clientId', 'deviceSerial', 'apTag', 'band', 'ssid', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -490,6 +502,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/clients/connectionStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -526,6 +539,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/clients/latencyStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', 'fields', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -563,6 +577,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/clients/{clientId}/connectionStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -609,6 +624,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/clients/{clientId}/connectivityEvents'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', 'types', 'includedSeverities', 'band', 'ssidNumber', 'deviceSerial', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['types', 'includedSeverities', ]
@@ -645,6 +661,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/clients/{clientId}/latencyHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -683,6 +700,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/clients/{clientId}/latencyStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', 'fields', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -718,6 +736,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/connectionStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -756,6 +775,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/dataRateHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', 'autoResolution', 'clientId', 'deviceSerial', 'apTag', 'band', 'ssid', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -791,6 +811,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/devices/connectionStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -827,6 +848,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/devices/latencyStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', 'fields', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -873,6 +895,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ethernet/ports/profiles'
 
         body_params = ['name', 'ports', 'usbPorts', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -974,6 +997,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ethernet/ports/profiles/{profileId}'
 
         body_params = ['name', 'ports', 'usbPorts', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1032,6 +1056,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/failedConnections'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', 'serial', 'clientId', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1074,6 +1099,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/latencyHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', 'autoResolution', 'clientId', 'deviceSerial', 'apTag', 'band', 'ssid', 'accessCategory', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1110,6 +1136,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/latencyStats'
 
         query_params = ['t0', 't1', 'timespan', 'band', 'ssid', 'vlan', 'apTag', 'fields', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1139,6 +1166,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/meshStatuses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
@@ -1164,6 +1192,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/rfProfiles'
 
         query_params = ['includeTemplateProfiles', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1206,6 +1235,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/rfProfiles'
 
         body_params = ['name', 'clientBalancingEnabled', 'minBitrateType', 'bandSelectionType', 'apBandSettings', 'twoFourGhzSettings', 'fiveGhzSettings', 'sixGhzSettings', 'transmission', 'perSsidSettings', 'flexRadios', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1250,6 +1280,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/rfProfiles/{rfProfileId}'
 
         body_params = ['name', 'clientBalancingEnabled', 'minBitrateType', 'bandSelectionType', 'apBandSettings', 'twoFourGhzSettings', 'fiveGhzSettings', 'sixGhzSettings', 'transmission', 'perSsidSettings', 'flexRadios', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1345,6 +1376,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/settings'
 
         body_params = ['meshingEnabled', 'ipv6BridgeEnabled', 'locationAnalyticsEnabled', 'upgradeStrategy', 'ledLightsOn', 'namedVlans', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1383,6 +1415,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/signalQualityHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', 'autoResolution', 'clientId', 'deviceSerial', 'apTag', 'band', 'ssid', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -1533,6 +1566,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}'
 
         body_params = ['name', 'enabled', 'authMode', 'enterpriseAdminAccess', 'encryptionMode', 'psk', 'wpaEncryptionMode', 'dot11w', 'dot11r', 'splashPage', 'splashGuestSponsorDomains', 'oauth', 'localRadius', 'ldap', 'activeDirectory', 'radiusServers', 'radiusProxyEnabled', 'radiusTestingEnabled', 'radiusCalledStationId', 'radiusAuthenticationNasId', 'radiusServerTimeout', 'radiusServerAttemptsLimit', 'radiusFallbackEnabled', 'radiusCoaEnabled', 'radiusFailoverPolicy', 'radiusLoadBalancingPolicy', 'radiusAccountingEnabled', 'radiusAccountingServers', 'radiusAccountingInterimInterval', 'radiusAttributeForGroupPolicies', 'ipAssignmentMode', 'useVlanTagging', 'concentratorNetworkId', 'secondaryConcentratorNetworkId', 'disassociateClientsOnVpnFailover', 'vlanId', 'defaultVlanId', 'apTagsAndVlanIds', 'walledGardenEnabled', 'walledGardenRanges', 'gre', 'radiusOverride', 'radiusGuestVlanEnabled', 'radiusGuestVlanId', 'minBitrate', 'bandSelection', 'perClientBandwidthLimitUp', 'perClientBandwidthLimitDown', 'perSsidBandwidthLimitUp', 'perSsidBandwidthLimitDown', 'lanIsolationEnabled', 'visible', 'availableOnAllAps', 'availabilityTags', 'mandatoryDhcpEnabled', 'adultContentFilteringEnabled', 'dnsRewrite', 'speedBurst', 'namedVlans', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1583,6 +1617,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/bonjourForwarding'
 
         body_params = ['enabled', 'rules', 'exception', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1632,6 +1667,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/deviceTypeGroupPolicies'
 
         body_params = ['enabled', 'deviceTypePolicies', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1683,6 +1719,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/eapOverride'
 
         body_params = ['timeout', 'identity', 'maxRetries', 'eapolKey', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1732,6 +1769,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/firewall/l3FirewallRules'
 
         body_params = ['rules', 'allowLanAccess', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1780,6 +1818,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/firewall/l7FirewallRules'
 
         body_params = ['rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1818,6 +1857,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/hotspot20'
 
         body_params = ['enabled', 'operator', 'venue', 'networkAccessType', 'domains', 'roamConsortOis', 'mccMncs', 'naiRealms', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -1890,6 +1930,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/identityPsks'
 
         body_params = ['name', 'passphrase', 'groupPolicyId', 'expiresAt', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)
@@ -1945,6 +1986,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/identityPsks/{identityPskId}'
 
         body_params = ['name', 'passphrase', 'groupPolicyId', 'expiresAt', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2018,6 +2060,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/schedules'
 
         body_params = ['enabled', 'ranges', 'rangesInSeconds', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2084,6 +2127,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/splash/settings'
 
         body_params = ['splashUrl', 'useSplashUrl', 'splashTimeout', 'redirectUrl', 'useRedirectUrl', 'welcomeMessage', 'splashLogo', 'splashImage', 'splashPrepaidFront', 'blockAllTrafficBeforeSignOn', 'controllerDisconnectionBehavior', 'allowSimultaneousLogins', 'guestSponsorship', 'billing', 'sentryEnrollment', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2116,6 +2160,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/trafficShaping/rules'
 
         body_params = ['trafficShapingEnabled', 'defaultRulesEnabled', 'rules', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2187,6 +2232,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/ssids/{number}/vpn'
 
         body_params = ['concentrator', 'splitTunnel', 'failover', ]
+        validate_kwargs(body_params)
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.put(metadata, resource, payload)
@@ -2225,6 +2271,7 @@ class Wireless(object):
         resource = f'/networks/{networkId}/wireless/usageHistory'
 
         query_params = ['t0', 't1', 'timespan', 'resolution', 'autoResolution', 'clientId', 'deviceSerial', 'apTag', 'band', 'ssid', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         return self._session.get(metadata, resource, params)
@@ -2260,6 +2307,7 @@ class Wireless(object):
         resource = f'/organizations/{organizationId}/wireless/devices/channelUtilization/byDevice'
 
         query_params = ['networkIds', 'serials', 'perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', 'interval', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', ]
@@ -2301,6 +2349,7 @@ class Wireless(object):
         resource = f'/organizations/{organizationId}/wireless/devices/channelUtilization/byNetwork'
 
         query_params = ['networkIds', 'serials', 'perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', 'interval', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', ]
@@ -2342,6 +2391,7 @@ class Wireless(object):
         resource = f'/organizations/{organizationId}/wireless/devices/channelUtilization/history/byDevice/byInterval'
 
         query_params = ['networkIds', 'serials', 'perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', 'interval', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', ]
@@ -2383,6 +2433,7 @@ class Wireless(object):
         resource = f'/organizations/{organizationId}/wireless/devices/channelUtilization/history/byNetwork/byInterval'
 
         query_params = ['networkIds', 'serials', 'perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', 'interval', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', ]
@@ -2419,6 +2470,7 @@ class Wireless(object):
         resource = f'/organizations/{organizationId}/wireless/devices/ethernet/statuses'
 
         query_params = ['perPage', 'startingAfter', 'endingBefore', 'networkIds', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', ]
@@ -2461,6 +2513,7 @@ class Wireless(object):
         resource = f'/organizations/{organizationId}/wireless/devices/packetLoss/byClient'
 
         query_params = ['networkIds', 'ssids', 'bands', 'macs', 'perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'ssids', 'bands', 'macs', ]
@@ -2503,6 +2556,7 @@ class Wireless(object):
         resource = f'/organizations/{organizationId}/wireless/devices/packetLoss/byDevice'
 
         query_params = ['networkIds', 'serials', 'ssids', 'bands', 'perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'ssids', 'bands', ]
@@ -2545,6 +2599,7 @@ class Wireless(object):
         resource = f'/organizations/{organizationId}/wireless/devices/packetLoss/byNetwork'
 
         query_params = ['networkIds', 'serials', 'ssids', 'bands', 'perPage', 'startingAfter', 'endingBefore', 't0', 't1', 'timespan', ]
+        validate_kwargs(query_params)
         params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
         array_params = ['networkIds', 'serials', 'ssids', 'bands', ]

--- a/meraki/common.py
+++ b/meraki/common.py
@@ -1,4 +1,5 @@
 import platform
+import inspect
 from meraki.exceptions import *
 
 
@@ -20,3 +21,31 @@ def check_python_version():
         )
 
         raise PythonVersionError(message)
+
+
+def validate_kwargs(supported_params: list[str]):
+    """
+    Validate if the kwargs in the calling function are among the supported parameters.
+
+    This function uses introspection to check the kwargs of the function that calls it.
+    It raises an exception if any unsupported parameters are found.
+
+    Args:
+        supported_params (List[str]): A list of supported parameter names.
+
+    Raises:
+        ValueError: If an unsupported parameter is found in the calling function's kwargs.
+    """
+    # Retrieve the calling function's frame
+    frame = inspect.currentframe()
+    # Get one frame back to access the calling function's frame
+    caller_frame = frame.f_back if frame else None
+
+    if caller_frame and 'kwargs' in caller_frame.f_locals:
+        # Extract kwargs from the calling function
+        kwargs = caller_frame.f_locals['kwargs']
+
+        # Check each kwarg against the list of supported parameters
+        for key in kwargs:
+            if key not in supported_params:
+                raise ValueError(f"Unsupported parameter: '{key}'")


### PR DESCRIPTION
# Incorrect kwarg is not logged or rejected


Hi,
I've come across an issue detailed in [GitHub Issue #212](https://github.com/meraki/dashboard-api-python/issues/212) regarding the Meraki Dashboard API where incorrect kwargs are neither logged nor rejected. I believe I have developed a solution that could effectively address this problem.

My approach involves adding a validation mechanism to ensure that only supported kwargs are accepted by the API functions. This would involve a function that cross-checks each kwarg against a predefined list of accepted parameters, raising an error or logging a warning for any unsupported kwargs.

I think this solution could significantly enhance the robustness of the API by preventing silent failures and providing clearer feedback to users. If this approach proves helpful, I am also ready to implement a similar solution for the aio (asynchronous) API service.

I am looking forward to your feedback on this suggestion and am happy to discuss further details or adjustments as needed
