### PR TITLE
fix missing ranges query-parameter in getOrganizationCameraDetections…

### DIFF
--- a/meraki/api/camera.py
+++ b/meraki/api/camera.py
@@ -865,19 +865,24 @@ class Camera(object):
         return self._session.delete(metadata, resource)
         
 
-
-    def getOrganizationCameraDetectionsHistoryByBoundaryByInterval(self, organizationId: str, boundaryIds: list, total_pages=1, direction='next', **kwargs):
+    def getOrganizationCameraDetectionsHistoryByBoundaryByInterval(self, organizationId: str, boundaryIds: list, startTime: str, endTime: str, interval: int, total_pages=1, direction='next', **kwargs):
         """
         **Returns analytics data for timespans**
         https://developer.cisco.com/meraki/api-v1/#!get-organization-camera-detections-history-by-boundary-by-interval
 
         - organizationId (string): Organization ID
         - boundaryIds (array): A list of boundary ids. The returned cameras will be filtered to only include these ids.
+        - startTime (string): The beginning of the timespan for the data.
+        - endTime (string): The end of the timespan for the data.
+        - interval (integer): The time ranges which the data is divided into. in seconds.
         - total_pages (integer or string): use with perPage to get total results up to total_pages*perPage; -1 or "all" for all pages
         - direction (string): direction to paginate, either "next" (default) or "prev" page
         - duration (integer): The minimum time, in seconds, that the person or car remains in the area to be counted. Defaults to boundary configuration or 60.
         - perPage (integer): The number of entries per page returned. Acceptable range is 1 - 1000. Defaults to 1000.
         - boundaryTypes (array): The detection types. Defaults to 'person'.
+        
+        Example:
+        >>> getOrganizationCameraDetectionsHistoryByBoundaryByInterval('1532855', ['5435354345'], '2024-04-23T00:00:00', '2024-05-23T23:59:59', 3600)
         """
 
         kwargs.update(locals())
@@ -897,6 +902,10 @@ class Camera(object):
             if k.strip() in array_params:
                 params[f'{k.strip()}[]'] = kwargs[f'{k}']
                 params.pop(k.strip())
+        
+        params['ranges[][startTime]'] = startTime
+        params['ranges[][endTime]'] = endTime
+        params['ranges[][interval]'] = interval
 
         return self._session.get_pages(metadata, resource, params, total_pages, direction)
         


### PR DESCRIPTION
***This pull request makes the following changes:***
* Fixes issue #253 

***Checklist***
- [X] Add `startTime, EndTime, interval` parameters to `getOrganizationCameraDetectionsHistoryByBoundaryByInterval`
- [X] Update docstring with the new parameters and add example to use the function
- [X] Add the missing query parameters
