### PR TITLE
Updated rest_session delete and deleteNetworkMerakiAuthUser to support optional parameters

### DIFF
--- a/generator/generate_library.py
+++ b/generator/generate_library.py
@@ -482,7 +482,7 @@ def generate_standard_and_async_functions(
 
             # Function body for DELETE endpoints
             elif method == "delete":
-                call_line, path_params = parse_delete_params(operation, parameters)
+                call_line, path_params, query_params = parse_delete_params(operation, parameters)
 
             # Add function to files
             with open(
@@ -569,9 +569,14 @@ def parse_post_and_put_params(method: str, operation: str, parameters: dict):
 
 
 def parse_delete_params(operation: str, parameters: dict):
+    query_params = parse_params(operation, parameters, "query")
     path_params = parse_params(operation, parameters, "path")
-    call_line = "return self._session.delete(metadata, resource)"
-    return call_line, path_params
+
+    if query_params:
+        call_line = "return self._session.delete(metadata, resource, params)"
+    else:
+        call_line = "return self._session.delete(metadata, resource)"
+    return call_line, path_params, query_params
 
 
 def generate_action_batch_functions(

--- a/meraki/api/networks.py
+++ b/meraki/api/networks.py
@@ -1658,8 +1658,12 @@ class Networks(object):
         networkId = urllib.parse.quote(str(networkId), safe='')
         merakiAuthUserId = urllib.parse.quote(str(merakiAuthUserId), safe='')
         resource = f'/networks/{networkId}/merakiAuthUsers/{merakiAuthUserId}'
+        
+        query_params = ['delete']
+        params = {k.strip(): v for k, v in kwargs.items() if k.strip() in query_params}
 
-        return self._session.delete(metadata, resource)
+
+        return self._session.delete(metadata, resource, params)
         
 
 

--- a/meraki/rest_session.py
+++ b/meraki/rest_session.py
@@ -498,6 +498,7 @@ class RestSession(object):
     def delete(self, metadata, url, json=None):
         metadata['method'] = 'DELETE'
         metadata['url'] = url
+        metadata['json'] = json
         response = self.request(metadata, 'DELETE', url, json=json)
         if response:
             response.close()

--- a/meraki/rest_session.py
+++ b/meraki/rest_session.py
@@ -495,10 +495,10 @@ class RestSession(object):
             response.close()
         return ret
 
-    def delete(self, metadata, url):
+    def delete(self, metadata, url, json=None):
         metadata['method'] = 'DELETE'
         metadata['url'] = url
-        response = self.request(metadata, 'DELETE', url)
+        response = self.request(metadata, 'DELETE', url, json=json)
         if response:
             response.close()
         return None


### PR DESCRIPTION
deleteNetworkMerakiAuthUser supports an optional boolean parameter of "delete" .
Currently, when passing "delete=True" in as a parameter, the user is not deleted but is just de-authorized.

This commit fixes that by enabling the rest_session delete to support json parameters.
Changes were tested and users are successfully deleted when passing delete=True as an argument.

dashboard.networks.deleteNetworkMerakiAuthUser(
    network_id, meraki_auth_user_id, delete=True
)

Tested with both "True" and "False" along with a request with no optional parameters (current behaviour).


