### PR TITLE
Instantiated the Spaces, WirelessController, CampusGateway, AsyncSpaces, AsyncWirelessController, and AsyncCampusGateway modules

### DIFF
--- a/meraki/__init__.py
+++ b/meraki/__init__.py
@@ -6,6 +6,7 @@ from meraki.api.appliance import Appliance
 # Batch class imports
 from meraki.api.batch import Batch
 from meraki.api.camera import Camera
+from meraki.api.campusGateway import CampusGateway
 from meraki.api.cellularGateway import CellularGateway
 from meraki.api.devices import Devices
 from meraki.api.insight import Insight
@@ -14,8 +15,10 @@ from meraki.api.networks import Networks
 from meraki.api.organizations import Organizations
 from meraki.api.sensor import Sensor
 from meraki.api.sm import Sm
+from meraki.api.spaces import Spaces
 from meraki.api.switch import Switch
 from meraki.api.wireless import Wireless
+from meraki.api.wirelessController import WirelessController
 # Config import
 from meraki.config import (
     API_KEY_ENVIRONMENT_VARIABLE,
@@ -182,6 +185,9 @@ class DashboardAPI(object):
         self.sm = Sm(self._session)
         self.switch = Switch(self._session)
         self.wireless = Wireless(self._session)
+        self.spaces = Spaces(self._session)
+        self.wirelessController = WirelessController(self._session)
+        self.campusGateway = CampusGateway(self._session)
 
         # Batch definitions
         self.batch = Batch()

--- a/meraki/aio/__init__.py
+++ b/meraki/aio/__init__.py
@@ -4,6 +4,7 @@ import os
 from meraki.aio.api.administered import AsyncAdministered
 from meraki.aio.api.appliance import AsyncAppliance
 from meraki.aio.api.camera import AsyncCamera
+from meraki.aio.api.campusGateway import AsyncCampusGateway
 from meraki.aio.api.cellularGateway import AsyncCellularGateway
 from meraki.aio.api.devices import AsyncDevices
 from meraki.aio.api.insight import AsyncInsight
@@ -12,8 +13,10 @@ from meraki.aio.api.networks import AsyncNetworks
 from meraki.aio.api.organizations import AsyncOrganizations
 from meraki.aio.api.sensor import AsyncSensor
 from meraki.aio.api.sm import AsyncSm
+from meraki.aio.api.spaces import AsyncSpaces
 from meraki.aio.api.switch import AsyncSwitch
 from meraki.aio.api.wireless import AsyncWireless
+from meraki.aio.api.wirelessController import AsyncWirelessController
 from meraki.aio.rest_session import *
 # Batch class imports
 from meraki.api.batch import Batch
@@ -181,6 +184,9 @@ class AsyncDashboardAPI:
         self.switch = AsyncSwitch(self._session)
         self.sm = AsyncSm(self._session)
         self.wireless = AsyncWireless(self._session)
+        self.spaces = AsyncSpaces(self._session)
+        self.wirelessController = AsyncWirelessController(self._session)
+        self.campusGateway = AsyncCampusGateway(self._session)
 
         # Batch definitions
         self.batch = Batch()


### PR DESCRIPTION
The Spaces, WirelessController, CampusGateway, AsyncSpaces, AsyncWirelessController, and AsyncCampusGateway modules are not usable by default because they have not been instantiated within the DashboardAPI and AsyncDashboardAPI classes. This pull request resolves that. 