### PR TITLE
Add wheel>=0.46.2 to fix CVE-2026-24049

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,5 @@ homepage = "https://github.com/meraki/dashboard-api-python"
 repository = "https://github.com/meraki/dashboard-api-python"
 
 [build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0","setuptools>=78.1.1,<79.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0","setuptools>=78.1.1,<79.0.0","wheel>=0.46.2"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### Summary
Adds `wheel>=0.46.2` to `[build-system].requires` to fix CVE-2026-24049 (GHSA-8rrh-rw8j-w5fx).

### Changes
- Added `wheel>=0.46.2` to `[build-system].requires` in `pyproject.toml`

### Why
- Fixes security vulnerability CVE-2026-24049 in wheel < 0.46.2
- Unblocks CI/CD security gates (pip-audit, safety, Snyk)
- Resolves compliance issues (ISO 27001, SOC2, NIS2)

### Testing
- Verified `[build-system].requires` includes `wheel>=0.46.2`
- Build completes successfully with `poetry build`

### Related
- Issue #313 