### PR TITLE
Enhance DHCP options in AsyncAppliance API v2.1.1

### DIFF
--- a/meraki/aio/api/appliance.py
+++ b/meraki/aio/api/appliance.py
@@ -2050,6 +2050,8 @@ class AsyncAppliance:
         - dhcpLeaseTime (string): The term of DHCP leases if the appliance is running a DHCP server on this VLAN. One of: '30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week'
         - mandatoryDhcp (object): Mandatory DHCP will enforce that clients connecting to this VLAN must use the IP address assigned by the DHCP server. Clients who use a static IP address won't be able to associate. Only available on firmware versions 17.0 and above
         - dhcpBootOptionsEnabled (boolean): Use DHCP boot options specified in other properties
+        - dhcpBootNextServer (string): DHCP boot option to direct boot clients to the server to load the boot file from
+        - dhcpBootFilename (string): DHCP boot option for boot filename
         - dhcpOptions (array): The list of DHCP options that will be included in DHCP responses. Each object in the list should have "code", "type", and "value" properties.
         """
 
@@ -2072,7 +2074,7 @@ class AsyncAppliance:
         networkId = urllib.parse.quote(str(networkId), safe='')
         resource = f'/networks/{networkId}/appliance/vlans'
 
-        body_params = ['id', 'name', 'subnet', 'applianceIp', 'groupPolicyId', 'templateVlanType', 'cidr', 'mask', 'ipv6', 'dhcpHandling', 'dhcpLeaseTime', 'mandatoryDhcp', 'dhcpBootOptionsEnabled', 'dhcpOptions', ]
+        body_params = ['id', 'name', 'subnet', 'applianceIp', 'groupPolicyId', 'templateVlanType', 'cidr', 'mask', 'ipv6', 'dhcpHandling', 'dhcpLeaseTime', 'mandatoryDhcp', 'dhcpBootOptionsEnabled', 'dhcpBootNextServer', 'dhcpBootFilename', 'dhcpOptions', ]
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)

--- a/meraki/api/appliance.py
+++ b/meraki/api/appliance.py
@@ -2050,6 +2050,8 @@ class Appliance(object):
         - dhcpLeaseTime (string): The term of DHCP leases if the appliance is running a DHCP server on this VLAN. One of: '30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week'
         - mandatoryDhcp (object): Mandatory DHCP will enforce that clients connecting to this VLAN must use the IP address assigned by the DHCP server. Clients who use a static IP address won't be able to associate. Only available on firmware versions 17.0 and above
         - dhcpBootOptionsEnabled (boolean): Use DHCP boot options specified in other properties
+        - dhcpBootNextServer (string): DHCP boot option to direct boot clients to the server to load the boot file from
+        - dhcpBootFilename (string): DHCP boot option for boot filename
         - dhcpOptions (array): The list of DHCP options that will be included in DHCP responses. Each object in the list should have "code", "type", and "value" properties.
         """
 
@@ -2072,7 +2074,7 @@ class Appliance(object):
         networkId = urllib.parse.quote(str(networkId), safe='')
         resource = f'/networks/{networkId}/appliance/vlans'
 
-        body_params = ['id', 'name', 'subnet', 'applianceIp', 'groupPolicyId', 'templateVlanType', 'cidr', 'mask', 'ipv6', 'dhcpHandling', 'dhcpLeaseTime', 'mandatoryDhcp', 'dhcpBootOptionsEnabled', 'dhcpOptions', ]
+        body_params = ['id', 'name', 'subnet', 'applianceIp', 'groupPolicyId', 'templateVlanType', 'cidr', 'mask', 'ipv6', 'dhcpHandling', 'dhcpLeaseTime', 'mandatoryDhcp', 'dhcpBootOptionsEnabled', 'dhcpBootNextServer', 'dhcpBootFilename', 'dhcpOptions', ]
         payload = {k.strip(): v for k, v in kwargs.items() if k.strip() in body_params}
 
         return self._session.post(metadata, resource, payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,5 @@ homepage = "https://github.com/meraki/dashboard-api-python"
 repository = "https://github.com/meraki/dashboard-api-python"
 
 [build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0","setuptools>=78.1.1,<79.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0","setuptools>=78.1.1,<79.0.0","wheel>=0.46.2"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
- Added new parameters: dhcpBootNextServer and dhcpBootFilename to support additional DHCP boot options in the appliance API documentation and request payload.

#312