### PR TITLE
AsyncRestSession: Fix handling JSONDecodeError for 404

### DIFF
--- a/meraki/aio/rest_session.py
+++ b/meraki/aio/rest_session.py
@@ -240,7 +240,10 @@ class AsyncRestSession:
                             message_is_dict = True
                         else:
                             message_is_dict = False
-                    except aiohttp.client_exceptions.ContentTypeError:
+                    except (
+                        json.decoder.JSONDecodeError,
+                        aiohttp.client_exceptions.ContentTypeError,
+                    ):
                         message_is_dict = False
                         try:
                             message = (await response.text())[:100]


### PR DESCRIPTION
The API returns HTML instead of JSON for 404 responses for nonexistent endpoints,
e.g., `GET "/networks/{networkId}/appliance/firewall/multicastForwarding"`.
(Note: the correct endpoint is `"/organizations/{organizationId}/appliance/firewall/multicastForwarding/byNetwork"`.)

`meraki.rest_session.RestSession` raises an `APIError` with `.status = 404`
and `message` set to the first few bytes of the HTML and `"please wait a minute if the key or org was just newly created."` appended: `"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtmplease wait a minute if the key or org was just newly created."`.

`meraki.aio.rest_session.AsyncRestSession`
instead tries to parse the message as JSON
and does not handle the resulting `JSONDecodeError`. That exception does not include the status code so it's not useful.

Fix the typo in handling JSON decode errors for 4xx responses.

To clarify the usecase: `nac-collector` aims to collect all of the (Meraki in this case) configuration from the API. Endpoint URLs are taken from Terraform provider definitions which are themselves based on the OpenAPI spec (POST/PUT endpoints) (e.g. https://github.com/CiscoDevNet/terraform-provider-meraki/blob/main/gen/definitions/appliance_firewall_multicast_forwarding.yaml#L4). All the responses, including error messages, are collected in a JSON using `AsyncRestSession.get_pages()` directly to request them: https://github.com/netascode/nac-collector/pull/186/changes#diff-1772d211aa8f1f65aa88019578f0f6f43ea10bbe13127726378c0e284e33b097R413.
Not requesting the nonexistent endpoints is taken care of in https://github.com/netascode/nac-collector/pull/185/changes/41c590a3c48a5d77e2964a2f03bbf3c1dcffae19, but handling the errors is still useful for any future cases (which will have to be worked around in the same way manually after the fact, at least for now).