### PR TITLE
ci: retry gh release list in watch-openapi (transient 401)

### DIFF
--- a/.github/workflows/watch-openapi-release.yml
+++ b/.github/workflows/watch-openapi-release.yml
@@ -25,7 +25,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST=$(gh release list --repo meraki/openapi --exclude-pre-releases --limit 1 --json tagName -q '.[0].tagName')
+          # Retry: api.github.com occasionally 401s a job's freshly-minted token.
+          for attempt in 1 2 3 4 5; do
+            if LATEST=$(gh release list --repo meraki/openapi --exclude-pre-releases --limit 1 --json tagName -q '.[0].tagName'); then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "::error::gh release list failed after 5 attempts"
+              exit 1
+            fi
+            echo "::warning::gh release list failed (attempt $attempt/5); retrying in $((attempt * 3))s"
+            sleep $((attempt * 3))
+          done
           API_VERSION="${LATEST#v}"
           # Reject anything that isn't a clean semver tag before it flows into
           # downstream run: steps / workflow_dispatch inputs (script injection guard).
@@ -68,7 +79,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST=$(gh release list --repo meraki/openapi --limit 20 --json tagName,isPrerelease -q '[.[] | select(.isPrerelease)] | .[0].tagName')
+          # Retry: api.github.com occasionally 401s a job's freshly-minted token.
+          for attempt in 1 2 3 4 5; do
+            if LATEST=$(gh release list --repo meraki/openapi --limit 20 --json tagName,isPrerelease -q '[.[] | select(.isPrerelease)] | .[0].tagName'); then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              echo "::error::gh release list failed after 5 attempts"
+              exit 1
+            fi
+            echo "::warning::gh release list failed (attempt $attempt/5); retrying in $((attempt * 3))s"
+            sleep $((attempt * 3))
+          done
           if [ -z "$LATEST" ]; then
             echo "has_new_release=false" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
Wrap the `gh release list --repo meraki/openapi` lookup in a 5-attempt backoff.

## Why
Run [27286337590](https://github.com/meraki/dashboard-api-python/actions/runs/27286337590) failed: `check-beta` got `401 Unauthorized` on its first `gh` call while `check-ga` and `check-dev` passed with the identical command and token. Each job mints its own `GITHUB_TOKEN` and hits `api.github.com` concurrently at startup; occasionally one token 401s on first use. A transient auth blip should not fail the whole scheduled run.

## Change
Retry loop (5 attempts, linear backoff) around each `gh release list` call in the check jobs. Errors out only after all attempts fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)