### PR TITLE
test(integration): fix flaky test_delete_network batch race

### DIFF
--- a/tests/integration/test_client_crud_lifecycle_async.py
+++ b/tests/integration/test_client_crud_lifecycle_async.py
@@ -201,6 +201,7 @@ async def test_delete_policy_objects(dashboard, org_id, version_salt):
 async def test_delete_network(dashboard, org_id, network):
     import asyncio
     from meraki.api.batch.networks import ActionBatchNetworks
+    from meraki.exceptions import AsyncAPIError
 
     action = ActionBatchNetworks().deleteNetwork(network["id"])
     max_attempts = 5
@@ -209,12 +210,21 @@ async def test_delete_network(dashboard, org_id, network):
         delay = 2**attempt
 
         await asyncio.sleep(delay)
-        batch = await dashboard.organizations.createOrganizationActionBatch(
-            organizationId=org_id,
-            actions=[action],
-            confirmed=False,
-            synchronous=False,
-        )
+        try:
+            batch = await dashboard.organizations.createOrganizationActionBatch(
+                organizationId=org_id,
+                actions=[action],
+                confirmed=False,
+                synchronous=False,
+            )
+        except AsyncAPIError as e:
+            # Action batches are asynchronous: a prior attempt's batch can
+            # finish deleting the network after we stopped observing it. The
+            # network being gone is the desired end state, so a "not found"
+            # here means the delete already succeeded.
+            if e.status == 400 and "not found" in str(e.message).lower():
+                return
+            raise
         assert batch is not None
         assert batch["id"]
 

--- a/tests/integration/test_client_crud_lifecycle_sync.py
+++ b/tests/integration/test_client_crud_lifecycle_sync.py
@@ -208,6 +208,7 @@ def test_delete_policy_objects(dashboard, org_id, version_salt):
 def test_delete_network(dashboard, org_id, network):
     import time
     from meraki.api.batch.networks import ActionBatchNetworks
+    from meraki.exceptions import APIError
 
     action = ActionBatchNetworks().deleteNetwork(network["id"])
     max_attempts = 5
@@ -216,12 +217,21 @@ def test_delete_network(dashboard, org_id, network):
         delay = 2**attempt
 
         time.sleep(delay)
-        batch = dashboard.organizations.createOrganizationActionBatch(
-            organizationId=org_id,
-            actions=[action],
-            confirmed=False,
-            synchronous=False,
-        )
+        try:
+            batch = dashboard.organizations.createOrganizationActionBatch(
+                organizationId=org_id,
+                actions=[action],
+                confirmed=False,
+                synchronous=False,
+            )
+        except APIError as e:
+            # Action batches are asynchronous: a prior attempt's batch can
+            # finish deleting the network after we stopped observing it. The
+            # network being gone is the desired end state, so a "not found"
+            # here means the delete already succeeded.
+            if e.status == 400 and "not found" in str(e.message).lower():
+                return
+            raise
         assert batch is not None
         assert batch["id"]
 


### PR DESCRIPTION
## Problem

`test_delete_network` has flaked on three recent dependabot PRs (#393, #394, #395) with:

> `createOrganizationActionBatch - 400 Bad Request, {'errors': ['Network with ID ... not found']}`

## Root cause

The test retries `createOrganizationActionBatch` up to 5 times. Action batches are **asynchronous/eventually-consistent**: a prior attempt's batch can finish deleting the network *after* the test stops polling its status. The next attempt then references a network that's already gone → 400 "not found".

The `network` fixture has no teardown, so this test is the sole deleter — the only way the network can be absent on attempt N>1 is that attempt N-1 already deleted it.

## Fix

A delete is idempotent. A 400 not-found on the create call means the network is already gone, which is the desired end state → return success. Applied to both sync and async lifecycle tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)