### PR TITLE
fix(ci): build changelog in regeneration PR, not via protected-branch push

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -81,34 +81,12 @@ jobs:
             exit 1
           fi
 
-      # Render changelog.d/ fragments into CHANGELOG.md and commit before the
-      # release is cut. Reuses the version already read from pyproject.toml, so
-      # there is no separate towncrier version to keep in sync. --generate-notes
-      # below remains as a fallback for the GitHub release body.
-      - name: Build changelog
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          BRANCH="${{ inputs.branch || github.event.workflow_run.head_branch }}"
-
-          # Nothing to do if there are no fragments to consume.
-          if ! ls changelog.d/*.md >/dev/null 2>&1; then
-            echo "No changelog fragments; skipping towncrier build."
-            exit 0
-          fi
-
-          pip install --quiet towncrier
-          towncrier build --yes --version "$VERSION"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md changelog.d/
-          if ! git diff --cached --quiet; then
-            git commit -m "docs: update changelog for $VERSION"
-            git push origin "HEAD:$BRANCH"
-          fi
-
+      # CHANGELOG.md is rendered from changelog.d/ fragments inside the
+      # regeneration PR (see regenerate-library.yml), so it is already on the
+      # branch by the time the release is cut. Committing/pushing here would
+      # bypass the branch's required status checks and be rejected by the
+      # ruleset, so no git write happens in this workflow. --generate-notes
+      # below produces the GitHub release body.
       - name: Create release
         if: steps.check-release.outputs.exists == 'false'
         env:

--- a/.github/workflows/regenerate-library.yml
+++ b/.github/workflows/regenerate-library.yml
@@ -101,6 +101,20 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"$LIBRARY_VERSION\"/" pyproject.toml
           uv lock
 
+      # Render changelog.d/ fragments into CHANGELOG.md here so the update rides
+      # the regeneration PR (and its required checks) instead of being pushed
+      # straight to a protected branch later. towncrier is in the dev group, so
+      # `uv sync --group generator` (default-groups = dev) already installed it.
+      - name: Build changelog
+        env:
+          LIBRARY_VERSION: ${{ github.event.inputs.library_version }}
+        run: |
+          if ls changelog.d/*.md >/dev/null 2>&1; then
+            uv run towncrier build --yes --version "$LIBRARY_VERSION"
+          else
+            echo "No changelog fragments; skipping towncrier build."
+          fi
+
       - name: Commit changes to new branch
         uses: EndBug/add-and-commit@v10
         with:


### PR DESCRIPTION
## Root cause

[Run 27302232244](https://github.com/meraki/dashboard-api-python/actions/runs/27302232244/job/80650738517) failed in `create-release.yml` → **Build changelog**:

```
remote: error: GH013: Repository rule violations found for refs/heads/httpx.
- 9 of 9 required status checks are expected.
 ! [remote rejected] HEAD -> httpx (push declined due to repository rule violations)
```

The step rendered `CHANGELOG.md` and pushed the commit **directly** to the release branch. `main`/`beta`/`httpx` rulesets require status checks; a bot commit pushed straight to the branch has none → rejected. The step also ran **unconditionally** (no `exists` guard), so it fired even though `4.1.0b1` already existed and *Create release* was correctly skipped. The changelog content never fails the checks; it just never reaches them.

## Fix

- **regenerate-library.yml**: build the changelog right after the version bump, so the rendered `CHANGELOG.md` + consumed fragments land in the **same regeneration PR** and ride its required checks. `towncrier` is in the `dev` group (`default-groups = ["dev"]`), already installed by `uv sync --group generator`.
- **create-release.yml**: remove the direct-push *Build changelog* step. By release time the changelog is already on the branch; the release body still uses `--generate-notes`.

No bypass actor needed — the changelog change now goes through the normal checks instead of around them.

## Distribution

Branches have drifted, but the removed *Build changelog* step is byte-identical across `main`/`beta`/`httpx`, and the regen insertion is in a shared region — cherry-picks cleanly. Will cherry-pick to `beta` and `httpx` after merge (never merge main down).

## Follow-up (not in this PR)

`changelog.d/+httpx-migration.changed.md` is still unconsumed on `origin/httpx` (its release was already cut). It'll fold into the next regen PR under this flow.