### PR TITLE
fix(ci): build changelog in regeneration PR, not via protected-branch push (beta)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -62,34 +62,12 @@ jobs:
             exit 1
           fi
 
-      # Render changelog.d/ fragments into CHANGELOG.md and commit before the
-      # release is cut. Reuses the version already read from pyproject.toml, so
-      # there is no separate towncrier version to keep in sync. --generate-notes
-      # below remains as a fallback for the GitHub release body.
-      - name: Build changelog
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          BRANCH="${{ inputs.branch || github.event.workflow_run.head_branch }}"
-
-          # Nothing to do if there are no fragments to consume.
-          if ! ls changelog.d/*.md >/dev/null 2>&1; then
-            echo "No changelog fragments; skipping towncrier build."
-            exit 0
-          fi
-
-          pip install --quiet towncrier
-          towncrier build --yes --version "$VERSION"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md changelog.d/
-          if ! git diff --cached --quiet; then
-            git commit -m "docs: update changelog for $VERSION"
-            git push origin "HEAD:$BRANCH"
-          fi
-
+      # CHANGELOG.md is rendered from changelog.d/ fragments inside the
+      # regeneration PR (see regenerate-library.yml), so it is already on the
+      # branch by the time the release is cut. Committing/pushing here would
+      # bypass the branch's required status checks and be rejected by the
+      # ruleset, so no git write happens in this workflow. --generate-notes
+      # below produces the GitHub release body.
       - name: Create release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/regenerate-library.yml
+++ b/.github/workflows/regenerate-library.yml
@@ -101,6 +101,20 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"$LIBRARY_VERSION\"/" pyproject.toml
           uv lock
 
+      # Render changelog.d/ fragments into CHANGELOG.md here so the update rides
+      # the regeneration PR (and its required checks) instead of being pushed
+      # straight to a protected branch later. towncrier is in the dev group, so
+      # `uv sync --group generator` (default-groups = dev) already installed it.
+      - name: Build changelog
+        env:
+          LIBRARY_VERSION: ${{ github.event.inputs.library_version }}
+        run: |
+          if ls changelog.d/*.md >/dev/null 2>&1; then
+            uv run towncrier build --yes --version "$LIBRARY_VERSION"
+          else
+            echo "No changelog fragments; skipping towncrier build."
+          fi
+
       - name: Commit changes to new branch
         uses: EndBug/add-and-commit@v10
         with:


### PR DESCRIPTION
Cherry-pick of #402 (0904f77) per the infra-distribution rule (cherry-pick across branches, never merge main down).

Removes the protected-branch changelog push from `create-release.yml` and builds the changelog inside the regeneration PR (`regenerate-library.yml`) so it rides the required checks. Drift auto-merged cleanly.