### PR TITLE
ci: sync create-release.yml to main on httpx

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -46,7 +46,21 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check if release already exists
+        id: check-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if gh release view "$VERSION" > /dev/null 2>&1; then
+            echo "Release $VERSION already exists, skipping."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Validate version matches branch
+        if: steps.check-release.outputs.exists == 'false'
         run: |
           BRANCH="${{ inputs.branch || github.event.workflow_run.head_branch }}"
           VERSION="${{ steps.version.outputs.version }}"
@@ -74,6 +88,7 @@ jobs:
       # ruleset, so no git write happens in this workflow. --generate-notes
       # below produces the GitHub release body.
       - name: Create release
+        if: steps.check-release.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
httpx's `create-release.yml` had drifted behind main. `workflow_dispatch` against httpx runs **httpx's** copy of the workflow, so this drift is live, not dead code.

## What httpx was missing vs main
- **Idempotency guard** — `Check if release already exists` step + `if: steps.check-release.outputs.exists == 'false'` gates. Without it, a re-dispatch on an already-released version errors instead of no-op.
- **`actions/create-github-app-token@v3`** (httpx pinned `@v2`)

## Preserved
The httpx-prerelease validation guard (`httpx` branch must have a prerelease version) and the `httpx` entry in the `workflow_run` branch list are retained — main's copy carries both, so the sync keeps them.

## What this PR does
File-level sync to main's exact content. No spec/library/generator changes. Resulting file is byte-identical to main's `create-release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)